### PR TITLE
feat(minish): add NixOS-WSL host

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Built on top of [flake-parts](https://flake.parts/), this setup manages system c
 | `marin` | Mac Mini as Airport Express | Apple | Mac Mini | Server | None | Audio + home services |
 | `iphone` | Personal phone | Apple | iPhone | Mobile | - | - |
 | `ipad` | Personal tablet | Apple | iPad | Tablet | - | - |
+| `minish` | NixOS-WSL instance on Windows | Microsoft | WSL2 | WSL | None | NixOS under Windows Subsystem for Linux |
 
 
 

--- a/flake.lock
+++ b/flake.lock
@@ -2668,6 +2668,30 @@
         "type": "github"
       }
     },
+    "nixos-wsl": {
+      "inputs": {
+        "flake-compat": [
+          "flake-compat"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777732699,
+        "narHash": "sha256-2uX/XtOWZ/oy2rerRynVhqVA//ZXZ3Fo60PikLHEPQc=",
+        "owner": "nix-community",
+        "repo": "NixOS-WSL",
+        "rev": "5482f113fd31ebac131d1ebeb2ae90bf0d5e41f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "main",
+        "repo": "NixOS-WSL",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1730200266,
@@ -3478,6 +3502,7 @@
         "nixcord": "nixcord",
         "nixos-facter-modules": "nixos-facter-modules",
         "nixos-generators": "nixos-generators",
+        "nixos-wsl": "nixos-wsl",
         "nixpkgs": "nixpkgs_17",
         "nixpkgs-cloudflared": "nixpkgs-cloudflared",
         "nixpkgs-mine": "nixpkgs-mine",

--- a/flake.nix
+++ b/flake.nix
@@ -222,6 +222,13 @@
       url = "github:nix-community/nixos-generators";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+    nixos-wsl = {
+      url = "github:nix-community/NixOS-WSL/main";
+      inputs = {
+        flake-compat.follows = "flake-compat";
+        nixpkgs.follows = "nixpkgs";
+      };
+    };
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     nixpkgs-cloudflared.url = "github:wrbbz/nixpkgs/cloudflared-2025.4.0";
     nixpkgs-mine.url = "github:Multipixelone/nixpkgs/init-soundshow";

--- a/modules/hosts.nix
+++ b/modules/hosts.nix
@@ -142,6 +142,16 @@ in
       desktopWindowManager = "None";
       notes = "Audio + home services";
     };
+    minish = {
+      isNixOS = true;
+      roles = [ "wsl" ];
+      description = "NixOS-WSL instance on Windows";
+      manufacturer = "Microsoft";
+      model = "WSL2";
+      readmeRole = "WSL";
+      desktopWindowManager = "None";
+      notes = "NixOS under Windows Subsystem for Linux";
+    };
     alexandria = {
       isNixOS = false;
       homeAddress = "192.168.6.9";

--- a/modules/minish/facter.json
+++ b/modules/minish/facter.json
@@ -1,0 +1,5 @@
+{
+  "version": 1,
+  "system": "x86_64-linux",
+  "virtualisation": "wsl"
+}

--- a/modules/minish/facter.nix
+++ b/modules/minish/facter.nix
@@ -1,0 +1,5 @@
+{
+  configurations.nixos.minish.module = {
+    facter.reportPath = ./facter.json;
+  };
+}

--- a/modules/minish/hostname.nix
+++ b/modules/minish/hostname.nix
@@ -1,0 +1,5 @@
+{
+  configurations.nixos.minish.module = {
+    networking.hostName = "minish";
+  };
+}

--- a/modules/minish/imports.nix
+++ b/modules/minish/imports.nix
@@ -1,0 +1,17 @@
+{ inputs, config, ... }:
+{
+  flake-file.inputs.nixos-wsl = {
+    url = "github:nix-community/NixOS-WSL/main";
+    inputs = {
+      nixpkgs.follows = "nixpkgs";
+      flake-compat.follows = "flake-compat";
+    };
+  };
+
+  configurations.nixos.minish.module = {
+    imports = (with config.flake.modules.nixos; [
+      base
+    ])
+    ++ [ inputs.nixos-wsl.nixosModules.default ];
+  };
+}

--- a/modules/minish/state-version.nix
+++ b/modules/minish/state-version.nix
@@ -1,0 +1,5 @@
+{
+  configurations.nixos.minish.module = {
+    system.stateVersion = "25.11";
+  };
+}

--- a/modules/minish/wsl.nix
+++ b/modules/minish/wsl.nix
@@ -7,6 +7,10 @@
       startMenuLaunchers = true;
     };
 
+    # WSL generates /etc/resolv.conf itself; let it own DNS instead of
+    # systemd-resolved (enabled by base via modules/network/dns.nix).
+    services.resolved.enable = false;
+
     # WSL boots via Microsoft's kernel; the host has no bootloader of its own.
     boot.loader.limine.enable = lib.mkForce false;
   };

--- a/modules/minish/wsl.nix
+++ b/modules/minish/wsl.nix
@@ -1,0 +1,13 @@
+{ lib, config, ... }:
+{
+  configurations.nixos.minish.module = {
+    wsl = {
+      enable = true;
+      defaultUser = config.flake.meta.owner.username;
+      startMenuLaunchers = true;
+    };
+
+    # WSL boots via Microsoft's kernel; the host has no bootloader of its own.
+    boot.loader.limine.enable = lib.mkForce false;
+  };
+}

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -197,8 +197,13 @@
                   content = builtins.readFile (../modules + "/${file}");
                   lines = lib.splitString "\n" content;
                   hasDotted = lib.any (l: builtins.match (dottedPattern name) l != null) lines;
-                  hasPackagesBlock =
-                    builtins.match ".*(^|[^A-Za-z0-9_.])packages[[:space:]]*=[[:space:]]*\\{.*" content != null;
+                  # Line-based to avoid std::regex stack overflow on large
+                  # files (libstdc++'s engine recurses on backtracking; a
+                  # whole-file `.*…packages…\{.*` blows the C stack on inputs
+                  # like modules/iot/homeassistant.nix).
+                  hasPackagesBlock = lib.any (
+                    l: builtins.match ".*(^|[^A-Za-z0-9_.])packages[[:space:]]*=[[:space:]]*\\{.*" l != null
+                  ) lines;
                   hasBare = lib.any (l: builtins.match (barePattern name) l != null) lines;
                 in
                 hasDotted || (hasPackagesBlock && hasBare);


### PR DESCRIPTION
Adds `minish` as a new NixOS host running under WSL2. Registers the
nixos-wsl input inline in the host's imports.nix following the
flake-file inline pattern, with hostname/state-version/facter/wsl
modules mirroring the structure of existing hosts.