### PR TITLE
feat(link/commutecompass): wire OpenClaw integration

### DIFF
--- a/modules/link/commutecompass.nix
+++ b/modules/link/commutecompass.nix
@@ -7,7 +7,20 @@
   };
 
   configurations.nixos.link.module =
-    { config, ... }:
+    { config, pkgs, ... }:
+    let
+      # Reuse the openclaw binary that modules/link/openclaw.nix installs into
+      # tunnel's home via `npm install -g openclaw`. The wrapper adds nodejs to
+      # PATH so the binary's `#!/usr/bin/env node` shebang resolves inside the
+      # commutecompass systemd sandbox.
+      openclawPkg = pkgs.writeShellApplication {
+        name = "openclaw";
+        runtimeInputs = [ pkgs.nodejs ];
+        text = ''
+          exec /home/tunnel/.npm-global/bin/openclaw "$@"
+        '';
+      };
+    in
     {
       imports = [ inputs.commutecompass.nixosModules.default ];
 
@@ -23,6 +36,31 @@
         configFile = "${inputs.secrets}/commutecompass/config.toml";
         venuesFile = "${inputs.secrets}/commutecompass/known_venues.yaml";
         environmentFile = config.age.secrets."commutecompass".path;
+
+        openclaw = {
+          package = openclawPkg;
+          # The real chat id is sourced from OPENCLAW_TARGET in tokens.age so
+          # it stays out of /nix/store. EnvironmentFile= is processed after
+          # Environment= in the generated unit, so the env file wins.
+          target = "set-via-OPENCLAW_TARGET-in-env-file";
+        };
       };
+
+      # Upstream sets ProtectHome=true, which hides /home/tunnel from the unit.
+      # Re-expose tunnel's npm prefix + openclaw state dir so the wrapper above
+      # can exec the binary and openclaw can read its channel config.
+      systemd.services =
+        let
+          bind = {
+            serviceConfig.BindReadOnlyPaths = [
+              "/home/tunnel/.npm-global"
+              "/home/tunnel/.openclaw"
+            ];
+          };
+        in
+        {
+          "commutecompass-morning" = bind;
+          "commutecompass-poll" = bind;
+        };
     };
 }


### PR DESCRIPTION
Upstream commutecompass now pipes morning/poll stdout through `openclaw message send`, which made `services.commutecompass.openclaw` required. Reuse the binary that modules/link/openclaw.nix already npm-installs for tunnel by wrapping it with nodejs on PATH, and re-expose /home/tunnel/{.npm-global,.openclaw} via BindReadOnlyPaths so the upstream ProtectHome=true sandbox doesn't black-hole it.

OPENCLAW_TARGET is sourced from the env file (tokens.age) so the Telegram chat id stays out of /nix/store; the openclaw.target option gets a sentinel because the upstream module requires it but the env file overrides at runtime.