### PR TITLE
feat(link/commutecompass): grant tunnel skill access to commutecompass

### DIFF
--- a/modules/link/commutecompass.nix
+++ b/modules/link/commutecompass.nix
@@ -28,7 +28,11 @@
         file = "${inputs.secrets}/commutecompass/tokens.age";
         owner = "commutecompass";
         group = "commutecompass";
-        mode = "0400";
+        # Group-readable so tunnel (added to commutecompass via skill.users
+        # below) can source the env file through the commutecompass-skill
+        # wrapper. Without this, on-demand chat dispatch can't load the API
+        # keys the systemd timers get via EnvironmentFile=.
+        mode = "0440";
       };
 
       services.commutecompass = {
@@ -36,6 +40,11 @@
         configFile = "${inputs.secrets}/commutecompass/config.toml";
         venuesFile = "${inputs.secrets}/commutecompass/known_venues.yaml";
         environmentFile = config.age.secrets."commutecompass".path;
+
+        # Lets tunnel (the openclaw gateway user) invoke skill scripts
+        # directly: installs `commutecompass-skill` on PATH and joins tunnel
+        # to the commutecompass group so it can read the env file above.
+        skill.users = [ "tunnel" ];
 
         openclaw = {
           package = openclawPkg;


### PR DESCRIPTION
Set services.commutecompass.skill.users = [ "tunnel" ] so the openclaw gateway user gets the commutecompass-skill wrapper on PATH and joins the commutecompass group. Bump the agenix secret to mode 0440 so the wrapper can source the env file as a group member; without this the chat-driven skill scripts can't load API keys.