### PR TITLE
choreops chore automations

### DIFF
--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -1,0 +1,496 @@
+# Home Assistant dashboards — storage mode vs declarative (Nix/YAML)
+
+How the household's HA dashboards are wired, **which of the two HA dashboard
+modes each one uses**, and how to revise either by hand or with an AI. The one
+rule that makes everything else make sense:
+
+> **A dashboard is editable in exactly one place. Pick the wrong place and your
+> change is either silently overwritten on the next rebuild, or silently lost on
+> the next UI save.**
+
+So before touching anything, identify the mode.
+
+## The two modes (read this first)
+
+Home Assistant Lovelace dashboards come in two mutually exclusive modes:
+
+|                         | **Storage mode**                                                                    | **YAML mode (declarative)**                                                                       |
+| ----------------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Source of truth         | HA's `.storage/lovelace*` (a DB-ish JSON blob)                                      | a `.yaml` file HA reads at startup                                                                |
+| Edited via              | the **UI** (three-dot → Edit dashboard) or the ha-mcp `ha_config_*_dashboard` tools | edit the **file**, then reload                                                                    |
+| Survives a Nix rebuild? | yes — Nix never touches `.storage`                                                  | the file is regenerated; **hand edits to the live config are wiped**                              |
+| Survives a UI "Edit"?   | yes                                                                                 | **no — YAML-mode dashboards aren't editable in the UI at all** (the editor is read-only / hidden) |
+| Our example             | `main-home` (the iPad kiosk)                                                        | `nixos-reorder` (the Reorder grid)                                                                |
+
+The trap is that **both modes look identical in the sidebar and render the same
+card types.** Nothing in the UI shouts "this one is declarative." You tell them
+apart by where they're defined (see the table below), not by looking at them.
+
+### Which of ours is which
+
+| Dashboard       | Sidebar title | Mode           | Where it's defined                                           | Touch it how                                         |
+| --------------- | ------------- | -------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
+| `main-home`     | **Main Home** | **storage**    | HA `.storage`, **not in this repo**                          | UI editor or ha-mcp; back up first                   |
+| `nixos-reorder` | **Reorder**   | **YAML / Nix** | `modules/iot/roomieorder.nix`, generated from `catalog.json` | edit `catalog.json` (or the generator), then rebuild |
+
+- **`main-home`** is the iPad wall kiosk. View 0 is the fridge dashboard. It is
+  storage mode _on purpose_ — it's hand-tuned in the UI and we don't want Nix
+  fighting the household's tweaks. It is **not** version-controlled here; the
+  only backups are JSON exports in `~/ha-dashboard-backups/`. **Never** point a
+  Nix `dashboards.*` block at it.
+- **`nixos-reorder`** is the opposite philosophy: a single sidebar entry whose
+  entire contents are derived from `catalog.json` and rebuilt on every
+  `nixos-rebuild`. Editing it live is pointless — the next rebuild overwrites it.
+
+---
+
+# The Reorder dashboard (declarative — the Nix-managed one)
+
+The "Reorder" sidebar entry is a one-view YAML-mode dashboard that shows one
+tappable button per orderable staple. It is generated, end to end, from
+`catalog.json`.
+
+## Data flow (single source of truth)
+
+```
+catalog.json  (in inputs.secrets, shared with the link service)
+      │
+      ▼
+inputs.roomieorder.lib.haButtons { catalogFile; endpoint; }   ← nix/ha-buttons.nix in the roomieorder flake
+      │   emits: restCommand · scripts · sensors · dashboardCard · dashboardCardDynamic
+      ▼
+modules/iot/roomieorder.nix   ← wires those into the HA config + a YAML-mode dashboard
+      │
+      ▼
+/nixos-reorder/reorder        ← the rendered grid (regenerated every rebuild)
+```
+
+`catalog.json` is the **only** file you edit to add/remove an item. It lives in
+`inputs.secrets` (`${inputs.secrets}/roomieorder/catalog.json`) and is shared by
+both hosts — the HA button generator on `iot` (`modules/iot/roomieorder.nix`)
+and the buy service on `link` (`modules/link/roomieorder.nix`). Add a staple
+there and its button, order script, and status sensor all appear on the next
+rebuild. That catalog edit is the _only_ step.
+
+## What `haButtons` emits
+
+`inputs.roomieorder.lib.haButtons` (source: `nix/ha-buttons.nix` in the
+`Multipixelone/roomieorder` flake) is a pure `catalog.json → HA fragments`
+function. From one catalog it returns:
+
+| Output                 | Goes into             | What it is                                                                                                                 |
+| ---------------------- | --------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `restCommand`          | `config.rest_command` | the `POST /reorder` call to the link service                                                                               |
+| `scripts`              | `iotHass.nixScripts`  | one `script.order_<key>` per item (this host routes Nix scripts through `iotHass.nixScripts`, a list — not `scriptsAttrs`) |
+| `sensors`              | `config.rest`         | one `GET /items` poll → one `sensor.roomieorder_<key>` per item, carrying the `on_cooldown` attribute                      |
+| `dashboardCard`        | a view's `cards`      | plain **core** `type: button` grid — the HACS-free fallback, no live state                                                 |
+| `dashboardCardDynamic` | a view's `cards`      | the **Mushroom** grid we actually use (gray-out + "N ago") — needs HACS `mushroom`                                         |
+
+`modules/iot/roomieorder.nix` feeds `dashboardCardDynamic` into a one-view
+dashboard and registers it as a YAML-mode dashboard:
+
+```nix
+reorderDashboard = yamlFormat.generate "lovelace-reorder.yaml" {
+  title = "Reorder";
+  views = [ { title = "Reorder"; path = "reorder"; icon = "mdi:cart";
+              cards = [ buttons.dashboardCardDynamic ]; } ];
+};
+# …
+lovelace.dashboards.nixos-reorder = {
+  mode = "yaml";
+  filename = "${reorderDashboard}";   # the store path IS the .yaml file
+  title = "Reorder"; icon = "mdi:cart"; show_in_sidebar = true;
+};
+systemd.services.home-assistant.reloadTriggers = [ reorderDashboard ];
+```
+
+A catalog change changes the derivation, which trips `reloadTriggers`, so the
+dashboard reloads on rebuild with **no** manual ha-mcp push. The iPad kiosk
+(`main-home`, storage mode) is left untouched.
+
+## The card it generates (the validated card vocabulary)
+
+Each item is **one** `custom:mushroom-template-card` (Mushroom, installed via
+HACS). Shape (from `mushroomCardFor` in `nix/ha-buttons.nix`):
+
+```yaml
+type: custom:mushroom-template-card
+primary: Dish Soap
+icon: mdi:bottle-tonic
+fill_container: true
+# teal when orderable, grey ("disabled") while on cooldown
+icon_color: >-
+  {% if is_state_attr('sensor.roomieorder_dish_soap','on_cooldown',true)
+  %}disabled{% else %}teal{% endif %}
+# "3 days ago" only while on cooldown
+secondary: >-
+  {% set s = states('sensor.roomieorder_dish_soap') %}
+  {% if is_state_attr('sensor.roomieorder_dish_soap','on_cooldown',true)
+  and s not in ['unknown','unavailable',''] %}{{ relative_time(as_datetime(s)) }} ago{% endif %}
+tap_action: { action: perform-action, perform_action: script.order_dish_soap }
+```
+
+The cards sit in a plain **`type: grid`** card (`columns: dashboardColumns`,
+`square: false`). If any catalog item sets a `category`, the layout becomes a
+`vertical-stack` of `## <Category>` markdown headings each followed by that
+category's grid (empty-category items group under **"Other"**); otherwise it's a
+single grid. Items sort alphabetically by button label within each group.
+
+> Note: this is a plain `grid` card, **not** a sections-view subgrid. There's no
+> `grid_options`/`column_span`/12-column-subgrid math here (that was the old
+> storage-mode layout). Card count per row is the single `dashboardColumns` knob.
+
+### The naming contract (don't break this)
+
+For an item with key `dish_soap`, three things must line up — and the generator
+keeps them aligned automatically, so you only break this if you hand-edit:
+
+| Thing             | Value                                       | Created by               |
+| ----------------- | ------------------------------------------- | ------------------------ |
+| Status sensor     | `sensor.roomieorder_dish_soap`              | `rest:` poll of `/items` |
+| Order script      | `script.order_dish_soap`                    | per-item HA script       |
+| Card `tap_action` | `perform-action` → `script.order_dish_soap` | the card                 |
+
+The card only ever fires the script; price/ASIN/cooldown all live server-side in
+`catalog.json`, so a mistyped card can't order the wrong thing or skip a guard.
+
+## Why Mushroom must be loaded (and how it is)
+
+`dashboardCardDynamic` uses `custom:mushroom-template-card`, so the Mushroom
+frontend JS must be served and registered as a Lovelace resource — even though
+the _default_ dashboard stays storage mode. `modules/iot/roomieorder.nix` ships
+it as a `customLovelaceModules` entry:
+
+```nix
+services.home-assistant.customLovelaceModules = [ pkgs.home-assistant-custom-lovelace-modules.mushroom ];
+```
+
+`modules/iot/homeassistant.nix` mirrors nixpkgs' behaviour: any
+`customLovelaceModules` entry (a) is served at
+`/local/nixos-lovelace-modules/mushroom.js`, (b) flips `lovelace.resource_mode`
+to `"yaml"`, and (c) emits the `lovelace.resources` entry that actually loads the
+JS. So the Mushroom cards render even though `main-home` is still storage mode.
+
+## Knobs
+
+Two things tune the generated grid, both passed through `catalog.json` /
+`haButtons`:
+
+- **`dashboardColumns`** (default `2`) — cards per row in the `grid` card.
+- per-item **`category`** in `catalog.json` — groups cards under a `## <category>`
+  heading. Omit it on every item and you get one flat grid.
+
+Other `haButtons` args worth knowing: `pollSeconds` (status re-poll interval,
+default 30 s), `statusSensorPrefix` (default `roomieorder_`), `defaultIcon`
+(`mdi:cart` when an item has no `icon`), `endpoint` (the link intake URL).
+
+## Gotchas (why it's built this way)
+
+- **Use `mushroom-template-card`, not `conditional` cards with `condition:
+template`.** HA's card editor flags template conditions as **"Conditions are
+  invalid"** and renders them as red error blocks. The single Mushroom card does
+  gray-out + timestamp via Jinja _inside_ the card (`icon_color`/`secondary`),
+  which HA evaluates freely — no `conditional` swap, no rejected conditions.
+- **`perform-action`, not `call-service`.** HA 2024.8+ renamed it; the key is
+  `perform_action` (underscore) inside `tap_action`.
+- **Cooldown is enforced server-side**, not by the dashboard. The gray-out is
+  purely visual — tapping a greyed item still calls the script, but the
+  roomieorder service rejects it (HTTP 200, no double order). Worst case of a
+  stale `on_cooldown` attribute is a harmless tap.
+- **`unknown` sensor state** = never ordered (no `last_placed_at`). The
+  `secondary` template guards `unknown`/`unavailable`/`''` so `as_datetime()`
+  never errors.
+- **Bad MDI icon name = blank card / "missing render."** An icon that doesn't
+  exist renders as nothing. Verify before using — quickest check is whether the
+  SVG exists:
+  `curl -so /dev/null -w "%{http_code}" https://raw.githubusercontent.com/Templarian/MaterialDesign-SVG/master/svg/<name>.svg`
+  (`200` = valid, `404` = doesn't exist), or search pictogrammers.com.
+
+## Adding / removing / restyling an item
+
+1. **Add/remove a staple:** edit `catalog.json` (in `inputs.secrets`). Add the
+   key with its `title`, optional `button`/`icon`/`category`. The script,
+   sensor, and card all follow on the next rebuild.
+2. **Restyle the whole grid:** change `dashboardColumns`, add `category` fields,
+   or (for a structural change) edit `nix/ha-buttons.nix` upstream.
+3. **Deploy:** `just colmena-apply-tag iot`. `reloadTriggers` reloads HA.
+4. **Never** edit the live `/nixos-reorder/reorder` view in the UI — it's YAML
+   mode, so the editor won't save, and a rebuild would overwrite it anyway.
+
+---
+
+# Editing the storage-mode kiosk (`main-home`)
+
+Different rules entirely, because there's no Nix source — `.storage` _is_ the
+source of truth.
+
+- **Back up first.** Export the dashboard JSON to `~/ha-dashboard-backups/`
+  before any non-trivial change (that's the only version history this dashboard
+  has).
+- **Via the UI:** open the dashboard, three-dot → Edit dashboard.
+- **Programmatically (ha-mcp):** it's storage mode, so use
+  `ha_config_set_dashboard` with a `python_transform`. Always pass the current
+  `config_hash` from `ha_config_get_dashboard` for optimistic locking; it
+  changes after every write. Sandbox limits: no `import`, no
+  f-strings/`.format()`, no `.replace()` — build strings with `+` concatenation.
+- **Don't try to "Nix-ify" it by pointing a `lovelace.dashboards.*` block at it.**
+  That would put it in YAML mode and make the household's UI edits impossible.
+  If you ever _do_ want it declarative, that's a migration (export → translate to
+  YAML → switch mode), not a config tweak. See **Migrating `main-home` to Nix**
+  below.
+
+---
+
+# Installed custom cards (the design palette)
+
+These are the HACS frontend modules installed on this HA. **Verify the live
+list** before relying on it: `ha_get_hacs_info(action="search",
+installed_only=True, category="lovelace")`.
+
+> ⚠️ **Most of these don't actually load right now.** See **The resource-mode
+> breakage** below. Only Mushroom renders today because it's the one module Nix
+> declares. The "Loads now?" column reflects reality on HA 2026.6.3, verified on
+> the box — not what's installed.
+
+| Card                                               | What it's for                                                     | In nixpkgs?                 | Loads now?  | Used on live `main_home` |
+| -------------------------------------------------- | ----------------------------------------------------------------- | --------------------------- | ----------- | ------------------------ |
+| **Mushroom** (`custom:mushroom-*`)                 | the workhorse — clean tiles/chips/template cards; the house look  | ✅ `mushroom`               | ✅ (Nix)    | yes (42+ cards)          |
+| **card-mod**                                       | CSS into (almost) any card — rounding, colors, fonts, hiding bits | ✅ `card-mod`               | ❌ orphaned | yes (styling)            |
+| **auto-entities**                                  | auto-populate a card's entity list from a filter                  | ✅ `auto-entities`          | ❌ orphaned | yes                      |
+| **mini-graph-card**                                | minimalist history graphs/sparklines                              | ✅ `mini-graph-card`        | ❌ orphaned | yes                      |
+| **Clock Weather Card**                             | iOS-style date/time + multi-day forecast                          | ✅ `clock-weather-card`     | ❌ orphaned | (recently)               |
+| **Atomic Calendar Revive**                         | advanced calendar/agenda card                                     | ✅ `atomic-calendar-revive` | ❌ orphaned | yes                      |
+| **Today Card**                                     | today's calendar schedule                                         | ❌ **not packaged**         | ❌ orphaned | yes (4 cards)            |
+| Kiosk Mode                                         | hides header/sidebar for wall tablets                             | ✅ `kiosk-mode`             | ❌ orphaned | kiosk chrome             |
+| Calendar Card Pro / Week / Daylight / Week-planner | various calendar layouts                                          | ❌ not packaged             | ❌ orphaned | no (dropped)             |
+
+So of the cards the live kiosk **uses**, everything except **Today Card** is
+already in nixpkgs — making them load is mostly wiring (see the plan below).
+
+**Reach-for guide** (once they load): Mushroom for almost everything; `card-mod`
+when Mushroom's options run out (it's a styling layer, not a card);
+`auto-entities` to avoid hand-listing entities; `mini-graph-card` for trends; a
+calendar card for agenda views. Don't emit a `custom:` card whose module isn't
+**declared in Nix** — it renders as **"Custom element doesn't exist."**
+
+---
+
+# Design best practices (making it look nice)
+
+Grounded in the current HA community consensus (sources at the bottom). These are
+the rules to bake into any dashboard work here.
+
+**Layout**
+
+- **Prefer the Sections view** (`type: sections`) over masonry/stacks. It's a
+  responsive grid: it re-flows columns to the screen width while keeping each
+  section's internal column count fixed, so card positions (muscle memory) stay
+  put across phone/tablet/kiosk. This is what `main-home` already uses.
+- **Group, don't sprawl.** Group related controls into one section with a
+  heading rather than scattering individual entity cards. A `heading` card per
+  section beats a wall of titled tiles.
+- **Keep the main view scannable** — aim for well under ~50 entities on the
+  primary view. Push detail onto secondary views or popups.
+- **Regular grid rhythm.** Let cards span whole grid columns/rows; consistent
+  card sizes read as "tidy." Section gap is the `--grid-gap` CSS var (default
+  32px) — tighten it via theme/`card-mod` for a denser kiosk.
+
+**Visual**
+
+- **"Answer questions before they're asked."** The card should surface the answer
+  ("how warm is it", "is the door locked") without a tap. Favor state-colored
+  icons (like the Reorder grid's teal/disabled) over raw text.
+- **One accent, restrained color.** Use color to mean something (on/off,
+  warn/ok), not for decoration. Mushroom's `icon_color` + a theme gives a
+  coherent palette for free.
+- **Mushroom + a theme + `card-mod`** is the house recipe for a polished look:
+  Mushroom for the card shapes, a dark theme for the kiosk, `card-mod` for the
+  last 10% (corner radius, hiding chevrons, conditional row coloring). ⚠️
+  `card-mod` is one of the **currently-orphaned** modules — its styling is
+  silently ignored until it's Nix-declared (see **The resource-mode breakage**).
+- **Whitespace is a feature.** Don't fill every cell; breathing room reads as
+  "designed."
+
+**Behavior**
+
+- **Conditional / template visibility** to hide irrelevant cards (the fridge
+  card already does this via its `valid_until` gate) — but remember the Reorder
+  gotcha: do conditionality _inside_ a Mushroom template card's Jinja, not via
+  `conditional` cards with `condition: template`, which HA's editor rejects.
+- **`tap`/`hold`/`double_tap` actions** give one tile multiple jobs (tap =
+  toggle, hold = more-info) and cut card count.
+
+---
+
+# The resource-mode breakage (verified — fix this first)
+
+**Right now, every HACS frontend card except Mushroom is broken**, and has been
+since Mushroom was wired into Nix. Verified on `colmena.iot`, HA 2026.6.3:
+
+- `configuration.yaml` (the nix-store one) sets `lovelace.resource_mode: yaml`
+  with a single resource: `/local/nixos-lovelace-modules/mushroom.js`. That entry
+  is emitted by `customLovelaceModules` in `modules/iot/homeassistant.nix`.
+- **HA's resource loading is exclusive: YAML resources _or_ the storage
+  collection, never both.** Defining any YAML `lovelace.resources` (which the
+  Mushroom wiring does) flips the whole instance to YAML mode and orphans HACS's
+  `.storage/lovelace_resources` collection — which still lists all ~12 plugins at
+  `/hacsfiles/...`, now dead.
+- The served index injects only HACS's `iconset.js` as an `extra_module_url`, not
+  the plugin cards — so there's no second load path saving them.
+- Net: the live `main_home` references `card-mod`, `auto-entities`,
+  `mini-graph-card`, `clock-weather-card`, `atomic-calendar-revive`, and
+  `today-card`, and **all of them render as "Custom element doesn't exist."**
+  Only the 50+ Mushroom cards work.
+
+**Verify any time** with `ha_config_list_dashboard_resources()` — if it returns
+only the Nix mushroom entry, everything else is orphaned.
+
+---
+
+# The fix / goal: all custom modules declared in Nix (single source of truth)
+
+Since we're already in YAML resource mode, the path _forward_ (not back to HACS)
+is to declare **every** frontend module in Nix so they all land in the YAML
+`resources` list and load. This both fixes the breakage and makes the repo the
+single source of truth for dashboard resources — no HACS deviation.
+
+This is **independent of, and a prerequisite for, migrating the dashboard config
+itself** (next section). Fixing resources does _not_ require touching `main_home`'s
+storage-mode layout — the existing cards start rendering as soon as their modules
+load.
+
+### Step 1 — declare the modules (the real fix)
+
+Add every used module to `services.home-assistant.customLovelaceModules` in
+`modules/iot/roomieorder.nix` (or a dedicated `modules/iot/lovelace-modules.nix`).
+nixpkgs status of the cards `main_home` actually uses, verified:
+
+| Module                         | nixpkgs `home-assistant-custom-lovelace-modules.*` |
+| ------------------------------ | -------------------------------------------------- |
+| `mushroom`                     | ✅ (already wired)                                 |
+| `card-mod`                     | ✅                                                 |
+| `auto-entities`                | ✅                                                 |
+| `mini-graph-card`              | ✅                                                 |
+| `clock-weather-card`           | ✅                                                 |
+| `atomic-calendar-revive`       | ✅                                                 |
+| `today-card` (`ha-today-card`) | ❌ **not packaged**                                |
+
+So six are one-liners; **only `today-card` needs work** — either a small
+`fetchzip`/`fetchFromGitHub` derivation (mirror the HACS derivation pattern in
+`modules/iot/homeassistant.nix`, which builds the `hacs` component itself), or
+swap those 4 `today-card` instances for a packaged calendar card. Sketch:
+
+```nix
+services.home-assistant.customLovelaceModules = with pkgs.home-assistant-custom-lovelace-modules; [
+  mushroom card-mod auto-entities mini-graph-card clock-weather-card atomic-calendar-revive
+  # + today-card  (custom derivation, see above)
+];
+```
+
+The existing `customLovelaceModules → lovelace.resources` merge in
+`homeassistant.nix` then emits one YAML resource per module, and the orphaned
+cards render. **`card-mod` must be in the list** or every `card_mod:` style block
+is silently ignored.
+
+### Step 2 — retire HACS's resource role
+
+Once all modules are Nix-declared, HACS is no longer the source of truth for
+frontend resources (it never effectively was, post-breakage). Options, in order of
+"single source of truth without deviation":
+
+- **Keep HACS for discovery only**, manage all _resources_ via Nix (current
+  direction — lowest risk). The stale `.storage/lovelace_resources` entries are
+  inert in YAML mode; optionally prune them so the two don't look like they
+  disagree.
+- **Drop HACS frontend modules entirely** and pin each card's version in Nix
+  (fully declarative, reproducible builds, no HACS update prompts). HACS the
+  _integration_ (custom_components) can stay for any non-frontend repos.
+
+Pin versions in the derivations either way, so a card update is a reviewed Nix
+bump, not a surprise.
+
+---
+
+# Migrating the `main_home` dashboard config to Nix (the larger goal)
+
+With resources fixed (above), the dashboard _layout_ can also move from storage
+mode to a Nix-generated YAML dashboard — the full single-source-of-truth end state.
+
+1. **Export** the live `main_home` JSON (start from `~/ha-dashboard-backups/`;
+   the live one is newer — pull it via the ha-mcp dashboard tools or off the box).
+2. **Translate** to a `sections`-view YAML structure and generate it with
+   `pkgs.formats.yaml`, exactly like `reorderDashboard` in
+   `modules/iot/roomieorder.nix`.
+3. **Register** it as a YAML dashboard (`lovelace.dashboards.nixos-home = { mode
+= "yaml"; filename = ...; }`) and add it to `reloadTriggers`. Decide whether it
+   _replaces_ storage `main-home` (repoint the kiosk URL) or coexists during cutover.
+4. **Trade-off:** once YAML-managed, the household can't tweak it from the UI —
+   every change is a repo edit + `just colmena-apply-tag iot`. That's the point
+   (version control, reproducibility), but it's a real change for a shared wall
+   tablet. Migrate the stable parts; leave genuinely fiddly bits in storage if needed.
+
+**Back up first**, always: export `main_home` JSON to `~/ha-dashboard-backups/`
+before cutover so you can restore the storage version.
+
+---
+
+# Asking an AI to generate or revise a dashboard
+
+This repo is set up so an AI can do dashboard work safely. Give it these
+guardrails in the prompt and the output will land first try:
+
+1. **State the target and its mode up front.** "Revise the YAML/Nix-generated
+   `nixos-reorder` dashboard" vs "revise the storage-mode `main-home` kiosk" lead
+   to completely different workflows (edit `catalog.json` + rebuild, vs ha-mcp
+   `python_transform` + `config_hash`). The #1 failure is an AI hand-editing a
+   YAML-mode dashboard live (silently overwritten) or trying to `python_transform`
+   a Nix-generated one.
+2. **Point it at the real source.** For Reorder, that's `catalog.json` and
+   `modules/iot/roomieorder.nix` (+ `nix/ha-buttons.nix` upstream) — not the
+   rendered view. For the kiosk, that's `.storage` via ha-mcp, with a backup to
+   `~/ha-dashboard-backups/` first.
+3. **Constrain the card vocabulary to what's installed.** Point it at the
+   **Installed custom cards** table above. Core cards (`button`, `markdown`,
+   `grid`, `vertical-stack`, `entities`, `sections`, `heading`, `tile`, `gauge`)
+   are always safe; `mushroom-*`, `card-mod`, `auto-entities`, `mini-graph-card`,
+   `clock-weather-card`, `calendar-card-pro` are installed. Anything else needs a
+   resource loaded first — for the Nix-managed dashboard that's a new
+   `customLovelaceModules` entry. Tell it **not** to invent `custom:` cards.
+4. **Aim it at the design rules** in **Design best practices**: Sections view,
+   group under headings, state-colored icons over text, Mushroom + theme +
+   `card-mod`, keep the main view under ~50 entities. "Make it look nice" lands
+   far better when the AI has these constraints than left open.
+5. **Bake in the gotchas:** `perform-action`/`perform_action` (not
+   `call-service`); no `conditional` + `condition: template` (use Jinja inside a
+   template card); validate every `mdi:` icon against the MaterialDesign-SVG repo;
+   guard `unknown`/`unavailable`/`''` before `as_datetime()`.
+6. **Tell it where state comes from.** Item liveness is
+   `sensor.roomieorder_<key>` + its `on_cooldown` attribute; ordering is
+   `script.order_<key>`; cooldown/price/ASIN are server-side in `catalog.json`.
+   The card never decides anything — it reads the sensor and fires the script.
+7. **Have it verify against live HA, then write Nix.** Per `AGENTS.md`: use the
+   ha-mcp `ha_*` tools to read entity state and dry-run service calls, but
+   **author the change as Nix** (`catalog.json` / `iotHass.*` /
+   `services.home-assistant.config.*`) — never `ha_config_set_yaml` /
+   `ha_write_file`, which drift from Nix. Deploy with
+   `just colmena-apply-tag iot`.
+
+Minimal prompt skeleton that works:
+
+> "Revise the **Reorder** dashboard (YAML mode, generated by
+> `modules/iot/roomieorder.nix` from `catalog.json`). I want `<change>`. Use
+> Mushroom template cards in a grid, keep the `roomieorder_<key>` /
+> `order_<key>` naming contract, validate icons, and show me the `catalog.json`
+> (or generator) diff plus the rebuild command — don't edit the live dashboard."
+
+---
+
+# Sources (design best practices)
+
+- [HA: A Home-Approved Dashboard — Sections view & grid system](https://www.home-assistant.io/blog/2024/03/04/dashboard-chapter-1/)
+- [HA docs: Sections view](https://www.home-assistant.io/dashboards/sections/)
+- [HA Community: Mushroom Cards + card-mod styling guide](https://community.home-assistant.io/t/mushroom-cards-card-mod-styling-config-guide/600472)
+- [piitaya/lovelace-mushroom (Mushroom + themes)](https://github.com/piitaya/lovelace-mushroom)
+- [ANTLATT: HA Dashboard Setup — the complete 2026 guide](https://www.antlatt.com/blog/home-assistant-dashboard-guide/)
+- [HomeShift: 25 HA dashboard examples that actually look good (2026)](https://joinhomeshift.com/home-assistant-dashboard-examples)
+- [HA Community: customize the `--grid-gap` between sections](https://community.home-assistant.io/t/customize-gap-between-new-sections-dashboard-layout/701480)

--- a/DASHBOARD.md
+++ b/DASHBOARD.md
@@ -31,16 +31,34 @@ apart by where they're defined (see the table below), not by looking at them.
 | Dashboard       | Sidebar title | Mode           | Where it's defined                                           | Touch it how                                         |
 | --------------- | ------------- | -------------- | ------------------------------------------------------------ | ---------------------------------------------------- |
 | `main-home`     | **Main Home** | **storage**    | HA `.storage`, **not in this repo**                          | UI editor or ha-mcp; back up first                   |
+| `nixos-home`    | **Home**      | **YAML / Nix** | `modules/iot/dashboard-home.nix`                             | edit the Nix, then rebuild                           |
 | `nixos-reorder` | **Reorder**   | **YAML / Nix** | `modules/iot/roomieorder.nix`, generated from `catalog.json` | edit `catalog.json` (or the generator), then rebuild |
+| `cod-chores`    | **Chores**    | **storage**    | **auto-managed by the ChoreOps integration**, not in repo    | don't edit — the integration regenerates it          |
 
 - **`main-home`** is the iPad wall kiosk. View 0 is the fridge dashboard. It is
   storage mode _on purpose_ — it's hand-tuned in the UI and we don't want Nix
   fighting the household's tweaks. It is **not** version-controlled here; the
   only backups are JSON exports in `~/ha-dashboard-backups/`. **Never** point a
   Nix `dashboards.*` block at it.
+- **`nixos-home`** is the declarative kiosk the iPad actually points at
+  (`/nixos-home/home?kiosk`). After the **Today** section it carries a
+  **Household** section: a ChoreOps points leaderboard (each card taps to that
+  person's `cod-chores` page) above a "needs doing" strip whose chips
+  **complete the chore inline on tap** — they press the chore's own per-owner
+  ChoreOps button (`button.<user>_choreops_approve_chore_<slug>`, the same
+  `button.press` cod-chores fires), behind a confirmation dialog. The eids are
+  resolved server-side in the chip's `auto-entities` template from each
+  `sensor.<user>_choreops_chore_status_<slug>`'s `claim_button_eid` /
+  `approve_button_eid` attribute.
 - **`nixos-reorder`** is the opposite philosophy: a single sidebar entry whose
   entire contents are derived from `catalog.json` and rebuilt on every
   `nixos-rebuild`. Editing it live is pointless — the next rebuild overwrites it.
+- **`cod-chores`** is generated and kept in sync by the ChoreOps integration
+  (per-person views, claim/approve via `custom:button-card` + `custom:auto-entities`,
+  both already in `customLovelaceModules` so it renders under our yaml resource
+  mode). `nixos-home` links to it **without** `?kiosk` so HA's chrome (sidebar +
+  per-person tabs) gives a way back and a way to switch roommates. **Don't**
+  hand-edit it (e.g. to add a back chip) — the integration will overwrite it.
 
 ---
 

--- a/docs/skills/choreops/SKILL.md
+++ b/docs/skills/choreops/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: choreops-ha-mcp
+description: Manage entities, services, and dashboards for the ChoreOps custom integration (ccpk1/choreops) in Home Assistant. Use when tracking chores, assigning points, managing gamification badges, or troubleshooting routines.
+---
+
+# ChoreOps Skill for HA MCP
+
+This skill provides the context and tooling map necessary to manage the [ChoreOps](https://github.com/ccpk1/choreops) custom integration via the [ha-mcp](https://github.com/homeassistant-ai/ha-mcp) server.
+
+## Overview
+
+ChoreOps is a sophisticated household task and routine manager. It manages:
+
+- **Profiles**: Flexible roles for every approver and doer.
+- **Chores**: Individual, shared, first-complete, and rotation models with advanced recurrence and overdue handling.
+- **Points/XP & Rewards**: Custom currency and claim-and-approve redemption workflows.
+- **Badges/Achievements**: Gamification progression with streaks and multipliers.
+
+## Terminology Mapping
+
+When querying configurations or building dashboards, be aware of the following terminology translations enforced by the integration:
+
+- **Cumulative Badges** (Underlying HA configuration/docs) $\rightarrow$ **Ranks** (Kid/User facing UI).
+- **Periodic Badges** (Underlying HA configuration/docs) $\rightarrow$ **Quests** (Kid/User facing UI).
+- **OpsCenter** $\rightarrow$ The unified admin view for managing approvals, point adjustments, and overrides.
+- **Rewards**: Must be created specifically as a `Reward` entity, not a `Chore`, to appear correctly in the Gamification dashboards.
+
+## Chore Assignment & Scoring Rules
+
+When creating, generating, or modifying chores, you must strictly adhere to the following point scale rules:
+
+- **Default Baseline**: The default point value for any standard chore is **5 points**.
+- **Difficulty Scaling**:
+  - Assign **> 5 points** (e.g., 10, 15, or more) if the task is physically demanding, time-consuming, or particularly difficult (e.g., mowing the lawn, deep cleaning the garage).
+  - Assign **< 5 points** (e.g., 1, 2, or 3) if the task is very easy, quick, or trivial (e.g., feeding the dog, making the bed).
+
+## Essential HA MCP Tools for ChoreOps
+
+### 1. Discovering State
+
+Use these tools to understand the current household setup before modifying anything:
+
+- `ha_search_entities`: Search for entities under the `choreops` domain or by a specific profile/user name.
+- `ha_get_state`: Inspect the current attributes of chore sensors, point balances, or badge progression (rich sensor data).
+- `ha_get_overview`: Identify if multiple instances of ChoreOps are running.
+
+### 2. Managing Operations (Services)
+
+Use `ha_call_service` to trigger ChoreOps actions natively. Always verify exact parameters using `ha_list_services` for the `choreops` domain. Crucial known services include:
+
+- **`choreops.set_rotation_turn`**: Forces the turn-holder for a rotation-based chore.
+  - _Data_: `chore_id` (or `chore_name`) and `user_id` (or `user_name`).
+- **`choreops.reset_rotation`**: Resets a rotation to the first assigned profile.
+  - _Data_: `chore_id` (or `chore_name`).
+- **`choreops.open_rotation_cycle`**: Temporarily allows any assigned profile to claim a rotation chore, regardless of whose turn it is.
+  - _Data_: `chore_id` (or `chore_name`).
+- **Lifecycle actions**: Automate `create`, `claim`, `approve`, `redeem`, and `adjust` operations via their respective `choreops.*` service calls.
+
+### 3. Dashboard Integration Rules (Strict)
+
+ChoreOps uses a dynamic, over-the-air dashboard generation system backed by the `ccpk1/choreops-dashboards` repository. If asked to modify or create Lovelace UI elements using MCP, adhere to these developer standards:
+
+- **Dynamic Lookups**: _Never manually construct or hardcode entity IDs_. Always use dynamic lookup patterns for dashboard helper entities and related sensors. Lookups must be integration-instance aware.
+- **Translations**: User-facing strings must use the translation sensor. Obtain user-facing text via `ui()` translation lookups rather than hardcoded text.
+
+## Workflow Best Practices
+
+1. **Live CRUD Updates**: Chore creation, edits, and deletions via services update runtime sensors and workflow buttons live _without_ needing an integration reload. You do not need to restart HA after making adjustments.
+2. **Actionable Notifications**: Leverage HA notification services in combination with ChoreOps state attributes to build custom reminders (e.g., escalating alerts for overdue tasks, low-battery smart locks linked to tasks).
+3. **Audit History**: Use `ha_get_history` or `ha_get_statistics` to track when chores were completed, claimed, or points were awarded over time.

--- a/flake.lock
+++ b/flake.lock
@@ -602,11 +602,11 @@
         "nixpkgs": "nixpkgs_8"
       },
       "locked": {
-        "lastModified": 1781621920,
-        "narHash": "sha256-EJw4JxTzyAtXATVYR5HdTdV6LtO0ovwshpWiQeWsLMs=",
+        "lastModified": 1781832332,
+        "narHash": "sha256-9g+st16fqUSnedrn0mv6jACvBqwntTYKbY1Allw5VN4=",
         "owner": "Multipixelone",
         "repo": "commutecompass",
-        "rev": "c9de55f95953fe47ca1ffb1c82c9cf404876bab3",
+        "rev": "b9d4bf5fa01453bbb6092ec0fd6b0761b720f0fa",
         "type": "github"
       },
       "original": {
@@ -1404,11 +1404,11 @@
         "nixpkgs": "nixpkgs_7"
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -1487,11 +1487,11 @@
         "nixpkgs": "nixpkgs_25"
       },
       "locked": {
-        "lastModified": 1778507602,
-        "narHash": "sha256-kTwur1wV+01SdqskVMSo6JMEpg71ps3HpbFY2GsflKs=",
+        "lastModified": 1781733627,
+        "narHash": "sha256-U3yTuGBnmXvXoQI3qkpfEDsn9RovQPAjN7ndRco+3u0=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "61ab0e80d9c7ab14c256b5b453d8b3fb0189ba0a",
+        "rev": "3bbec39bc90eadfa031e6f3b77272f3f60803e39",
         "type": "github"
       },
       "original": {
@@ -3266,11 +3266,11 @@
     },
     "nixpkgs_26": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -3406,11 +3406,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1781074563,
-        "narHash": "sha256-md8WlXOlfnIeHeOScMTTHFyf2d6iaTwPl2apR5EQ3P4=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9ae611a455b90cf061d8f332b977e387bda8e1ca",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -3705,11 +3705,11 @@
         "nixpkgs": "nixpkgs_26"
       },
       "locked": {
-        "lastModified": 1781712760,
-        "narHash": "sha256-Hbplzc2wg4vbg79KcywaMjr30wTrGV30ZqjTX8H5jlE=",
+        "lastModified": 1781928820,
+        "narHash": "sha256-Hlh4hKw5M/7R4bCpypKXYeDY80kkHuJi6MSu+Luix8Q=",
         "owner": "Multipixelone",
         "repo": "roomieorder",
-        "rev": "5668ccec0ed83019d750fdeaec76dd609b45e003",
+        "rev": "a281e8d02d269f483f253208cac1929c4368338f",
         "type": "github"
       },
       "original": {

--- a/modules/iot/choreops.nix
+++ b/modules/iot/choreops.nix
@@ -1,0 +1,133 @@
+# One-time seed script for ChoreOps consumable chores.
+#
+# ChoreOps state is storage-backed (.storage/choreops), not declarative — chores
+# are created by calling `choreops.create_chore`, not by editing Nix. This script
+# documents the 7 consumable chore definitions in-repo and creates them in a
+# single run. Trigger it ONCE via `script.choreops_seed_consumable_chores`
+# (HA UI or ha_call_service); re-running would create duplicate chores.
+#
+# Assignment split: chores that involve buying/swapping a part are Finn-only
+# (the household doesn't want roommates purchasing parts); cleaning chores stay
+# shared. Finn-only chores use completion_criteria "independent" — ChoreOps adds
+# no global-status sensor for them, so completion shows on
+# `sensor.finn_choreops_chore_status_<slug>`. Shared chores use "shared_first",
+# which exposes `sensor.office_system_choreops_<slug>_global_status`.
+#
+# The Eufy/Levoit telemetry automations in homeassistant.nix make these chores
+# due via `choreops.set_chore_due_date`; the reverse completion-sync there
+# presses the matching Eufy hardware reset button when a chore is completed.
+{
+  configurations.nixos.iot.module =
+    let
+      mkChore =
+        {
+          name,
+          icon,
+          points,
+          completion_criteria,
+          assigned,
+          description,
+        }:
+        {
+          service = "choreops.create_chore";
+          data = {
+            inherit
+              name
+              icon
+              points
+              description
+              ;
+            assigned_user_names = assigned;
+            inherit completion_criteria;
+            # Mirror the existing water chores: clear the due date immediately
+            # once the chore goes late, and reset approvals at midnight.
+            overdue_handling = "at_due_date_clear_immediate_on_late";
+            approval_reset_type = "at_midnight_once";
+          };
+        };
+
+      shared = [
+        "Finn"
+        "Ciara"
+        "Holland"
+      ];
+      finn = [ "Finn" ];
+
+      chores = [
+        # ── Shared cleaning chores (no purchase) ──
+        {
+          name = "Clean Vacuum Nav Sensors";
+          icon = "mdi:eye-check";
+          points = 5;
+          completion_criteria = "shared_first";
+          assigned = shared;
+          description = "Wipe the vacuum's IR/cliff nav sensors with a dry microfibre cloth.";
+        }
+        {
+          name = "Clean Vacuum Cleaning Tray";
+          icon = "mdi:tray-alert";
+          points = 5;
+          completion_criteria = "shared_first";
+          assigned = shared;
+          description = "Rinse the vacuum mopping tray and clear any debris.";
+        }
+        {
+          name = "Wash Vacuum Mop Cloth";
+          icon = "mdi:dishwasher";
+          points = 5;
+          completion_criteria = "shared_first";
+          assigned = shared;
+          description = "Wash the vacuum mopping cloth (or replace if worn).";
+        }
+        # ── Finn-only chores (buying/swapping a part) ──
+        {
+          name = "Replace Vacuum HEPA Filter";
+          icon = "mdi:air-filter";
+          points = 10;
+          completion_criteria = "independent";
+          assigned = finn;
+          description = "Install a new HEPA filter in the vacuum.";
+        }
+        {
+          name = "Replace Vacuum Rolling Brush";
+          icon = "mdi:broom";
+          points = 10;
+          completion_criteria = "independent";
+          assigned = finn;
+          description = "Install a new rolling brush in the vacuum.";
+        }
+        {
+          name = "Replace Vacuum Side Brush";
+          icon = "mdi:broom";
+          points = 8;
+          completion_criteria = "independent";
+          assigned = finn;
+          description = "Install a new side brush in the vacuum.";
+        }
+        {
+          name = "Order Levoit Filter Sponges";
+          icon = "mdi:air-filter";
+          points = 3;
+          completion_criteria = "independent";
+          assigned = finn;
+          description = "Order replacement Levoit humidifier filter sponges.";
+        }
+      ];
+    in
+    {
+      iotHass.nixScripts = [
+        {
+          id = "choreops_seed_consumable_chores";
+          alias = "ChoreOps — seed consumable chores";
+          description = ''
+            One-time: create the 7 consumable ChoreOps chores (3 shared cleaning,
+            4 Finn-only replace/order) that the Eufy/Levoit telemetry automations
+            make due. Run exactly once — re-running creates duplicate chores.
+          '';
+          mode = "single";
+          icon = "mdi:playlist-plus";
+          sequence = map mkChore chores;
+        }
+      ];
+    };
+}

--- a/modules/iot/choreops.nix
+++ b/modules/iot/choreops.nix
@@ -6,12 +6,18 @@
 # single run. Trigger it ONCE via `script.choreops_seed_consumable_chores`
 # (HA UI or ha_call_service); re-running would create duplicate chores.
 #
-# Assignment split: chores that involve buying/swapping a part are Finn-only
-# (the household doesn't want roommates purchasing parts); cleaning chores stay
-# shared. Finn-only chores use completion_criteria "independent" — ChoreOps adds
-# no global-status sensor for them, so completion shows on
-# `sensor.finn_choreops_chore_status_<slug>`. Shared chores use "shared_first",
-# which exposes `sensor.office_system_choreops_<slug>_global_status`.
+# Assignment split: only the part-purchasing chore (Order Levoit Filter Sponges)
+# is Finn-only — the household doesn't want roommates purchasing parts. Part-swap
+# chores (filter/brush installs) and cleaning chores are shared. The Finn-only
+# order chore uses completion_criteria "independent" — ChoreOps adds no
+# global-status sensor for it, so completion shows on
+# `sensor.finn_choreops_chore_status_<slug>`. Cleaning chores use "shared_first"
+# (exposing `sensor.office_system_choreops_<slug>_global_status`); part-swap
+# chores use "rotation_primary_standby" with Finn as primary and the roommates as
+# standbys who can claim once the chore is overdue (standby_claim_mode
+# "on_overdue"). Primary/standby chores expose NO global-status sensor; the
+# overall state is mirrored as the `global_state` attribute on each assignee's
+# `sensor.<user>_choreops_chore_status_<slug>`.
 #
 # The Eufy/Levoit telemetry automations in homeassistant.nix make these chores
 # due via `choreops.set_chore_due_date`; the reverse completion-sync there
@@ -27,6 +33,12 @@
           completion_criteria,
           assigned,
           description,
+          standby_claim_mode ? null,
+          # Default mirrors the water chores: clear the due date immediately once
+          # the chore goes late. The primary/standby part-swap chores override
+          # this to "at_due_date" so the chore persists while overdue and a
+          # standby can still claim it for the points.
+          overdue_handling ? "at_due_date_clear_immediate_on_late",
         }:
         {
           service = "choreops.create_chore";
@@ -38,12 +50,12 @@
               description
               ;
             assigned_user_names = assigned;
-            inherit completion_criteria;
-            # Mirror the existing water chores: clear the due date immediately
-            # once the chore goes late, and reset approvals at midnight.
-            overdue_handling = "at_due_date_clear_immediate_on_late";
+            # Reset approvals at midnight.
+            inherit completion_criteria overdue_handling;
             approval_reset_type = "at_midnight_once";
-          };
+          }
+          # standby_claim_mode only applies to rotation_primary_standby chores.
+          // (if standby_claim_mode == null then { } else { inherit standby_claim_mode; });
         };
 
       shared = [
@@ -58,7 +70,7 @@
         {
           name = "Clean Vacuum Nav Sensors";
           icon = "mdi:eye-check";
-          points = 5;
+          points = 3;
           completion_criteria = "shared_first";
           assigned = shared;
           description = "Wipe the vacuum's IR/cliff nav sensors with a dry microfibre cloth.";
@@ -66,7 +78,7 @@
         {
           name = "Clean Vacuum Cleaning Tray";
           icon = "mdi:tray-alert";
-          points = 5;
+          points = 3;
           completion_criteria = "shared_first";
           assigned = shared;
           description = "Rinse the vacuum mopping tray and clear any debris.";
@@ -74,40 +86,50 @@
         {
           name = "Wash Vacuum Mop Cloth";
           icon = "mdi:dishwasher";
-          points = 5;
+          points = 4;
           completion_criteria = "shared_first";
           assigned = shared;
           description = "Wash the vacuum mopping cloth (or replace if worn).";
         }
-        # ── Finn-only chores (buying/swapping a part) ──
+        # ── Shared part-swap chores (Finn primary, roommates standby) ──
+        # Finn normally does these, but if he lets one go overdue a roommate can
+        # claim it for the points. Installing a part Finn already bought is fine
+        # to share — only the purchasing chore below stays Finn-only.
         {
           name = "Replace Vacuum HEPA Filter";
           icon = "mdi:air-filter";
-          points = 10;
-          completion_criteria = "independent";
-          assigned = finn;
+          points = 5;
+          completion_criteria = "rotation_primary_standby";
+          assigned = shared;
+          standby_claim_mode = "on_overdue";
+          overdue_handling = "at_due_date";
           description = "Install a new HEPA filter in the vacuum.";
         }
         {
           name = "Replace Vacuum Rolling Brush";
           icon = "mdi:broom";
-          points = 10;
-          completion_criteria = "independent";
-          assigned = finn;
+          points = 5;
+          completion_criteria = "rotation_primary_standby";
+          assigned = shared;
+          standby_claim_mode = "on_overdue";
+          overdue_handling = "at_due_date";
           description = "Install a new rolling brush in the vacuum.";
         }
         {
           name = "Replace Vacuum Side Brush";
           icon = "mdi:broom";
-          points = 8;
-          completion_criteria = "independent";
-          assigned = finn;
+          points = 4;
+          completion_criteria = "rotation_primary_standby";
+          assigned = shared;
+          standby_claim_mode = "on_overdue";
+          overdue_handling = "at_due_date";
           description = "Install a new side brush in the vacuum.";
         }
+        # ── Finn-only chore (purchasing a part) ──
         {
           name = "Order Levoit Filter Sponges";
           icon = "mdi:air-filter";
-          points = 3;
+          points = 2;
           completion_criteria = "independent";
           assigned = finn;
           description = "Order replacement Levoit humidifier filter sponges.";
@@ -121,8 +143,9 @@
           alias = "ChoreOps — seed consumable chores";
           description = ''
             One-time: create the 7 consumable ChoreOps chores (3 shared cleaning,
-            4 Finn-only replace/order) that the Eufy/Levoit telemetry automations
-            make due. Run exactly once — re-running creates duplicate chores.
+            3 shared part-swap with Finn as primary, 1 Finn-only order) that the
+            Eufy/Levoit telemetry automations make due. Run exactly once —
+            re-running creates duplicate chores.
           '';
           mode = "single";
           icon = "mdi:playlist-plus";

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -1,0 +1,1254 @@
+# nixos-home — a declarative, Nix-generated home dashboard.
+#
+# This is the single-source-of-truth counterpart to the storage-mode iPad kiosk
+# (`main-home`, UI-managed, NOT in this repo). It reproduces the kiosk's first
+# ("Fridge") view — people locations, per-person calendars, the subway board,
+# weather, cleaning status and light scenes — as a YAML-mode dashboard generated
+# from Nix, so it regenerates on every rebuild with no manual ha-mcp push.
+#
+# It also owns the FULL set of custom Lovelace modules for this host (the single
+# `customLovelaceModules` list): emitting any `lovelace.resources` flips HA to
+# yaml resource_mode, which orphans HACS's storage resource collection, so every
+# `custom:` card a dashboard uses must be declared here or it renders as "Custom
+# element doesn't exist". See DASHBOARD.md. roomieorder.nix consumes `mushroom`
+# from this list (it no longer declares its own).
+#
+# This dashboard REPLACES the storage kiosk: the iPad (vnc-ipad.nix) points at
+# /nixos-home/home?kiosk. It carries the full kiosk: the home view plus the
+# cleaning, lights and week sub-views (all declarative here). The Reorder chip
+# crosses to the separate `nixos-reorder` dashboard (same catalog.json generator,
+# so not a second source of truth); that dashboard has a Back chip home.
+# `?kiosk` chrome (hidden header/sidebar) is the kiosk-mode plugin, declared below.
+# The storage `main-home` dashboard is left intact as a fallback.
+_: {
+  configurations.nixos.iot.module =
+    { pkgs, ... }:
+    let
+      yamlFormat = pkgs.formats.yaml { };
+
+      # Per-person "today" agenda. Swaps the kiosk's unpackaged `custom:today-card`
+      # for atomic-calendar-revive (in nixpkgs) limited to a single day, so the
+      # whole dashboard stays declarable from Nix.
+      calendarToday = cal: color: {
+        type = "custom:atomic-calendar-revive";
+        name = "Today";
+        maxDaysToShow = 1;
+        maxEventCount = 10;
+        showLoader = false;
+        showDate = false;
+        showLocation = false;
+        showCalendarName = false;
+        showNoEventsForToday = true;
+        hideFinishedEvents = true;
+        disableEventLink = true;
+        compactMode = true;
+        hoursOnSameLine = true;
+        eventDateFormat = "ddd MMM D";
+        language = "en";
+        entities = [
+          {
+            entity = cal;
+            inherit color;
+          }
+        ];
+        tap_action = {
+          action = "navigate";
+          navigation_path = "/nixos-home/week?kiosk";
+        };
+      };
+
+      # Back-to-home chip that opens every sub-view (kiosk has no sidebar).
+      backChip = {
+        type = "custom:mushroom-chips-card";
+        alignment = "start";
+        chips = [
+          {
+            type = "template";
+            icon = "mdi:arrow-left";
+            content = "Back";
+            tap_action = {
+              action = "navigate";
+              navigation_path = "/nixos-home/home?kiosk";
+            };
+          }
+        ];
+      };
+
+      # A "clean this room" button → vacuum.clean_area for one cleaning_area_id.
+      roomCard = name: icon: color: areaId: {
+        type = "custom:mushroom-template-card";
+        primary = name;
+        inherit icon;
+        icon_color = color;
+        tap_action = {
+          action = "perform-action";
+          perform_action = "vacuum.clean_area";
+          target.entity_id = "vacuum.vaccum";
+          data.cleaning_area_id = [ areaId ];
+        };
+      };
+
+      # A scene tile → scene.turn_on.
+      sceneCard = name: icon: color: scene: {
+        type = "custom:mushroom-template-card";
+        primary = name;
+        inherit icon;
+        icon_color = color;
+        tap_action = {
+          action = "perform-action";
+          perform_action = "scene.turn_on";
+          target.entity_id = scene;
+        };
+      };
+
+      # A needle gauge with optional unit / severity.
+      gauge =
+        {
+          entity,
+          name,
+          min,
+          max,
+          unit ? null,
+          severity ? null,
+        }:
+        {
+          type = "gauge";
+          inherit
+            entity
+            name
+            min
+            max
+            ;
+          needle = true;
+        }
+        // (if unit == null then { } else { inherit unit; })
+        // (if severity == null then { } else { inherit severity; });
+
+      # A Mushroom light card with the controls toggled per fixture.
+      lightCard =
+        {
+          entity,
+          name,
+          icon,
+          brightness ? true,
+          colorTemp ? false,
+          color ? false,
+          useLightColor ? false,
+          collapsible ? null,
+        }:
+        {
+          type = "custom:mushroom-light-card";
+          inherit entity name icon;
+        }
+        // (if useLightColor then { use_light_color = true; } else { })
+        // (if brightness then { show_brightness_control = true; } else { })
+        // (if colorTemp then { show_color_temp_control = true; } else { })
+        // (if color then { show_color_control = true; } else { })
+        // (if collapsible == null then { } else { collapsible_controls = collapsible; });
+
+      homeView = {
+        type = "sections";
+        title = "Home";
+        path = "home";
+        max_columns = 4;
+
+        badges = [
+          {
+            type = "custom:mushroom-template-badge";
+            content = "{{ now().strftime('%a %b %d') }}";
+            icon = "mdi:calendar";
+          }
+          {
+            type = "entity";
+            entity = "sensor.humidifier_humidity";
+            name = "Humidity";
+            show_state = true;
+            show_name = true;
+            show_icon = true;
+          }
+          {
+            type = "entity";
+            entity = "sensor.openweathermap_temperature";
+            name = "Outside";
+            show_state = true;
+            show_name = true;
+            show_icon = true;
+          }
+          {
+            type = "custom:mushroom-template-badge";
+            content = "{{ ((states('sensor.kingston_throop_n_next_arrival') | as_datetime - now()).total_seconds() / 60) | round(0, 'floor') | int }}m";
+            icon = "mdi:subway-variant";
+            color = "{% set m = ((states('sensor.kingston_throop_n_next_arrival') | as_datetime - now()).total_seconds() / 60) | round(0, 'floor') | int %}{% if m < 5 %}orange{% else %}primary{% endif %}";
+          }
+          {
+            type = "entity";
+            entity = "sensor.openweathermap_peak_rain_chance_12h";
+            show_state = true;
+            show_name = false;
+            show_icon = true;
+            visibility = [
+              {
+                condition = "numeric_state";
+                entity = "sensor.openweathermap_peak_rain_chance_12h";
+                above = 0;
+              }
+            ];
+          }
+          {
+            type = "entity";
+            entity = "sensor.openweathermap_uv_index";
+            name = "UV";
+            show_state = true;
+            show_name = true;
+            show_icon = true;
+            visibility = [
+              {
+                condition = "numeric_state";
+                entity = "sensor.openweathermap_uv_index";
+                above = 5;
+              }
+            ];
+          }
+        ];
+
+        sections = [
+          # ── Meds alert (only renders when a dose is pending) ──────────────
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "conditional";
+                conditions = [
+                  {
+                    entity = "binary_sensor.meds_needed";
+                    state = "on";
+                  }
+                ];
+                card = {
+                  type = "markdown";
+                  card_mod.style = {
+                    "." = ''
+                      ha-card {
+                        background: linear-gradient(135deg, #c62828 0%, #b71c1c 100%);
+                        color: #fff;
+                        --card-primary-text-color: #fff;
+                        --card-secondary-text-color: rgba(255, 255, 255, 0.85);
+                        --ha-card-border-radius: 16px;
+                        padding: 20px 24px;
+                        font-size: 1.3em;
+                        border: 2px solid rgba(255, 255, 255, 0.15);
+                        box-shadow: 0 8px 32px rgba(183, 28, 28, 0.4);
+                      }
+                    '';
+                    "ha-markdown$" = ''
+                      .markdown-body h2 { margin: 0 0 8px 0; }
+                      .markdown-body p { margin: 0; }
+                    '';
+                  };
+                  content = ''
+                    {% set morning = state_attr('binary_sensor.meds_needed', 'morning_pending') %}
+                    {% set night   = state_attr('binary_sensor.meds_needed', 'night_pending') %}
+                    {% if morning and night %}
+                    ## <ha-icon icon="mdi:alert-circle"></ha-icon> Morning & Night Meds
+                    **Both** still need to be taken today.
+                    {% elif morning %}
+                    ## <ha-icon icon="mdi:alert-circle"></ha-icon> Morning Meds
+                    Not taken yet today.
+                    {% elif night %}
+                    ## <ha-icon icon="mdi:alert-circle"></ha-icon> Night Meds
+                    Not taken yet tonight.
+                    {% endif %}
+                  '';
+                };
+              }
+            ];
+          }
+
+          # ── Vacuum / humidifier consumable warnings (auto-populated chips) ─
+          {
+            type = "grid";
+            column_span = 4;
+            cards = [
+              {
+                type = "custom:auto-entities";
+                card_param = "chips";
+                show_empty = false;
+                card = {
+                  type = "custom:mushroom-chips-card";
+                  alignment = "start";
+                };
+                filter.template = ''
+                  [
+                  {%- set entries = [
+                    ('sensor.vaccum_filter_remaining', 'Filter', 'mdi:air-filter'),
+                    ('sensor.vaccum_rolling_brush_remaining', 'Roller', 'mdi:rotate-3d-variant'),
+                    ('sensor.vaccum_side_brush_remaining', 'Side brush', 'mdi:fan'),
+                    ('sensor.vaccum_mopping_cloth_remaining', 'Mop', 'mdi:waves'),
+                    ('sensor.vaccum_sensor_remaining', 'Sensors', 'mdi:eye-outline'),
+                    ('sensor.vaccum_cleaning_tray_remaining', 'Tray', 'mdi:wiper'),
+                  ] -%}
+                  {%- for s, label, icon in entries -%}
+                    {%- set t = state_attr(s, 'total_life_hours') | float(0) -%}
+                    {%- if t > 0 -%}
+                      {%- set pct = (states(s) | float(0) / t * 100) | int -%}
+                      {%- if pct < 20 -%}
+                        {'entity': '{{ s }}', 'type': 'template', 'icon': '{{ icon }}', 'icon_color': 'orange', 'content': '{{ label }} {{ pct }}%', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
+                      {%- endif -%}
+                    {%- endif -%}
+                  {%- endfor -%}
+                  {%- set sponge = states('sensor.humidifier_filter_lifetime') | float(100) -%}
+                  {%- if sponge < 30 -%}
+                    {'entity': 'sensor.humidifier_filter_lifetime', 'type': 'template', 'icon': 'mdi:air-filter', 'icon_color': 'orange', 'content': 'Sponge {{ sponge | int }}%', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
+                  {%- endif -%}
+                  {%- if is_state('binary_sensor.humidifier_low_water', 'on') -%}
+                    {'entity': 'binary_sensor.humidifier_low_water', 'type': 'template', 'icon': 'mdi:water-alert', 'icon_color': 'red', 'content': 'Tank empty', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
+                  {%- endif -%}
+                  {%- set err = states('sensor.vaccum_error_message') | string -%}
+                  {%- if err and err | length > 0 and err != 'unknown' and err != 'unavailable' -%}
+                    {'entity': 'sensor.vaccum_error_message', 'type': 'template', 'icon': 'mdi:robot-vacuum-alert', 'icon_color': 'red', 'content': '{{ err }}', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}}
+                  {%- endif -%}
+                  ]
+                '';
+              }
+            ];
+          }
+
+          # ── Fridge nudges (LLM-written reminders; hidden when empty) ───────
+          {
+            type = "grid";
+            column_span = 4;
+            cards = [
+              {
+                type = "markdown";
+                content = ''
+                  {% set lines = state_attr('sensor.fridge_nudges', 'lines') or [] %}{% if lines %}{% for line in lines %}- {{ line }}
+                  {% endfor %}{% endif %}'';
+                visibility = [
+                  {
+                    condition = "state";
+                    entity = "sensor.fridge_nudges";
+                    state_not = [
+                      ""
+                      "unknown"
+                      "unavailable"
+                    ];
+                  }
+                ];
+                card_mod.style = {
+                  "." = ''
+                    ha-card {   background: linear-gradient(135deg, rgba(245,158,11,0.10), rgba(245,158,11,0.02)) !important;   border-radius: 16px !important;   border: none !important;   border-left: 4px solid var(--warning-color, #f59e0b) !important;   box-shadow: 0 2px 10px rgba(0,0,0,0.06) !important; }
+                  '';
+                  "ha-markdown$" = ''
+                    .markdown-body { padding: 2px 6px; } ul { padding-left: 0; margin: 0; list-style: none; } li {   font-size: 1.25em;   font-weight: 500;   line-height: 1.45;   padding: 8px 4px 8px 32px;   position: relative;   letter-spacing: -0.005em;   border-bottom: 1px solid rgba(245,158,11,0.12); } li:last-child { border-bottom: none; } li::before {   content: "";   position: absolute;   left: 8px;   top: 0.85em;   width: 10px;   height: 10px;   border-radius: 50%;   background: var(--warning-color, #f59e0b);   box-shadow: 0 0 10px rgba(245,158,11,0.5); }
+                  '';
+                };
+              }
+            ];
+          }
+
+          # ── Finn: presence, today's calendar, chores ──────────────────────
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Finn";
+                heading_style = "title";
+                badges = [
+                  {
+                    type = "entity";
+                    show_state = true;
+                    show_icon = true;
+                    entity = "sensor.nougat_battery_level";
+                    color = "state";
+                  }
+                ];
+              }
+              {
+                type = "custom:mushroom-person-card";
+                entity = "person.finn";
+                fill_container = false;
+                secondary_info = "last-changed";
+                primary_info = "state";
+                icon_type = "entity-picture";
+              }
+              {
+                type = "custom:mushroom-person-card";
+                entity = "person.emily";
+                fill_container = false;
+                secondary_info = "last-changed";
+                primary_info = "state";
+                icon_type = "entity-picture";
+              }
+              (calendarToday "calendar.finn" "#f97316")
+              {
+                display_order = "duedate_asc";
+                type = "todo-list";
+                entity = "todo.chores";
+                hide_create = false;
+                hide_completed = true;
+                hide_section_headers = true;
+              }
+            ];
+          }
+
+          # ── Ciara: presence, today's calendar, shopping list ──────────────
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Ciara";
+                heading_style = "title";
+                badges = [
+                  {
+                    type = "entity";
+                    show_state = true;
+                    show_icon = true;
+                    entity = "sensor.ciaras_iphone_battery_level";
+                    color = "state";
+                  }
+                ];
+              }
+              {
+                type = "custom:mushroom-person-card";
+                entity = "person.ciara";
+                primary_info = "state";
+                secondary_info = "last-changed";
+                icon_type = "entity-picture";
+              }
+              {
+                type = "custom:mushroom-person-card";
+                entity = "person.holland";
+                primary_info = "state";
+                secondary_info = "last-changed";
+                icon_type = "entity-picture";
+              }
+              (calendarToday "calendar.ciara" "#10b981")
+              {
+                display_order = "none";
+                type = "todo-list";
+                entity = "todo.foodtown";
+                hide_completed = true;
+                hide_section_headers = true;
+              }
+            ];
+          }
+
+          # ── Home: quick toggles, media, weather, subway, cleaning, lights ─
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Home";
+                heading_style = "title";
+                badges = [
+                  {
+                    type = "entity";
+                    entity = "vacuum.vaccum";
+                    color = "state";
+                    show_state = true;
+                  }
+                ];
+              }
+              {
+                type = "custom:mushroom-chips-card";
+                alignment = "end";
+                chips = [
+                  {
+                    type = "template";
+                    icon = "mdi:calendar-week";
+                    icon_color = "blue";
+                    content = "Week";
+                    tap_action = {
+                      action = "navigate";
+                      navigation_path = "/nixos-home/week?kiosk";
+                    };
+                  }
+                  {
+                    type = "template";
+                    entity = "input_boolean.guest_mode";
+                    icon = "mdi:account-group";
+                    icon_color = "{{ 'indigo' if is_state('input_boolean.guest_mode', 'on') else 'disabled' }}";
+                    content = "Guest · {{ 'On' if is_state('input_boolean.guest_mode', 'on') else 'Off' }}";
+                    tap_action.action = "toggle";
+                  }
+                  {
+                    type = "template";
+                    entity = "input_boolean.welcome_home_lights_enabled";
+                    icon = "mdi:home-import-outline";
+                    icon_color = "{{ 'amber' if is_state('input_boolean.welcome_home_lights_enabled', 'on') else 'disabled' }}";
+                    content = "Welcome · {{ 'On' if is_state('input_boolean.welcome_home_lights_enabled', 'on') else 'Off' }}";
+                    tap_action.action = "toggle";
+                  }
+                  {
+                    type = "template";
+                    entity = "input_boolean.vacuum_auto_skip_today";
+                    icon = "mdi:robot-vacuum-off";
+                    icon_color = "{{ 'red' if is_state('input_boolean.vacuum_auto_skip_today', 'on') else 'disabled' }}";
+                    content = "Skip vac · {{ 'On' if is_state('input_boolean.vacuum_auto_skip_today', 'on') else 'Off' }}";
+                    tap_action.action = "toggle";
+                  }
+                  {
+                    type = "template";
+                    entity = "input_boolean.living_room_appletv_dim_enabled";
+                    icon = "mdi:television-shimmer";
+                    icon_color = "{{ 'purple' if is_state('input_boolean.living_room_appletv_dim_enabled', 'on') else 'disabled' }}";
+                    content = "TV dim · {{ 'On' if is_state('input_boolean.living_room_appletv_dim_enabled', 'on') else 'Off' }}";
+                    tap_action.action = "toggle";
+                  }
+                  {
+                    type = "template";
+                    icon = "mdi:cart";
+                    icon_color = "teal";
+                    content = "Reorder";
+                    tap_action = {
+                      action = "navigate";
+                      navigation_path = "/nixos-reorder/reorder?kiosk";
+                    };
+                  }
+                ];
+              }
+              {
+                type = "media-control";
+                entity = "media_player.living_room";
+                grid_options = {
+                  columns = 12;
+                  rows = "auto";
+                };
+                visibility = [
+                  {
+                    condition = "state";
+                    entity = "media_player.living_room";
+                    state_not = "off";
+                  }
+                ];
+              }
+              {
+                type = "custom:clock-weather-card";
+                entity = "weather.openweathermap";
+              }
+              {
+                type = "markdown";
+                content = ''
+                  {% set next = states('sensor.kingston_throop_n_next_arrival') | as_datetime %}
+                  {% set second = states('sensor.kingston_throop_n_second_arrival') | as_datetime %}
+                  {% set third = states('sensor.kingston_throop_n_third_arrival') | as_datetime %}
+                  {% set n = ((next - now()).total_seconds() / 60) | round(0, 'floor') | int if next else '--' %}
+                  {% set s = ((second - now()).total_seconds() / 60) | round(0, 'floor') | int if second else '--' %}
+                  {% set t = ((third - now()).total_seconds() / 60) | round(0, 'floor') | int if third else '--' %}
+
+                  ### <span>C</span> ↑ Manhattan
+
+                  # **{{ n }}**<small> min</small> &nbsp;·&nbsp; **{{ s }}** &nbsp;·&nbsp; **{{ t }}**'';
+                card_mod.style."ha-markdown$" = ''
+                  h3 span {
+                    display: inline-flex;
+                    align-items: center;
+                    justify-content: center;
+                    width: 1.6em;
+                    height: 1.6em;
+                    border-radius: 50%;
+                    background-color: #0039A6;
+                    color: #fff;
+                    font-weight: 700;
+                    font-size: 0.85em;
+                    vertical-align: middle;
+                    margin-right: 6px;
+                  }
+                  h1 {
+                    font-variant-numeric: tabular-nums;
+                    letter-spacing: -0.02em;
+                  }
+                '';
+              }
+              {
+                type = "tile";
+                entity = "vacuum.vaccum";
+                name = "Vacuum";
+                features_position = "bottom";
+                features = [
+                  {
+                    type = "vacuum-commands";
+                    commands = [
+                      "start_pause"
+                      "return_home"
+                      "locate"
+                    ];
+                  }
+                ];
+                hold_action = {
+                  action = "navigate";
+                  navigation_path = "/nixos-home/cleaning?kiosk";
+                };
+              }
+              {
+                type = "tile";
+                entity = "humidifier.humidifier";
+                name = "Humidifier";
+                features_position = "bottom";
+                features = [ { type = "target-humidity"; } ];
+              }
+              {
+                type = "custom:mini-graph-card";
+                name = "Inside 24h";
+                entities = [
+                  {
+                    entity = "sensor.humidifier_humidity";
+                    name = "Humidity";
+                    color = "#3b82f6";
+                  }
+                  {
+                    entity = "sensor.humidifier_temperature";
+                    name = "Temp";
+                    color = "#f59e0b";
+                    y_axis = "secondary";
+                    show_state = true;
+                  }
+                ];
+                hours_to_show = 24;
+                points_per_hour = 2;
+                line_width = 2;
+                height = 90;
+                show = {
+                  name = true;
+                  icon = false;
+                  state = true;
+                  legend = false;
+                  extrema = false;
+                  labels = false;
+                  labels_secondary = false;
+                  fill = "fade";
+                };
+                animate = false;
+                smoothing = true;
+              }
+              {
+                type = "heading";
+                heading = "Lights";
+                heading_style = "subtitle";
+                icon = "mdi:lightbulb-multiple-outline";
+              }
+              {
+                type = "custom:mushroom-chips-card";
+                alignment = "center";
+                chips = [
+                  {
+                    type = "template";
+                    icon = "mdi:lightbulb-off";
+                    icon_color = "disabled";
+                    content = "All off";
+                    tap_action = {
+                      action = "perform-action";
+                      perform_action = "light.turn_off";
+                      target.entity_id = "all";
+                    };
+                  }
+                  {
+                    type = "entity";
+                    entity = "scene.living_room_bright";
+                    content_info = "name";
+                    name = "Bright";
+                    icon = "mdi:weather-sunny";
+                    icon_color = "amber";
+                    tap_action = {
+                      action = "perform-action";
+                      perform_action = "scene.turn_on";
+                      target.entity_id = "scene.living_room_bright";
+                    };
+                  }
+                  {
+                    type = "entity";
+                    entity = "scene.living_room_soho";
+                    content_info = "name";
+                    name = "Soho";
+                    icon = "mdi:lamp";
+                    icon_color = "deep-orange";
+                    tap_action = {
+                      action = "perform-action";
+                      perform_action = "scene.turn_on";
+                      target.entity_id = "scene.living_room_soho";
+                    };
+                  }
+                  {
+                    type = "entity";
+                    entity = "scene.living_room_relax";
+                    content_info = "name";
+                    name = "Relax";
+                    icon = "mdi:sofa";
+                    icon_color = "orange";
+                    tap_action = {
+                      action = "perform-action";
+                      perform_action = "scene.turn_on";
+                      target.entity_id = "scene.living_room_relax";
+                    };
+                  }
+                  {
+                    type = "entity";
+                    entity = "scene.living_room_nightlight";
+                    content_info = "name";
+                    name = "Night";
+                    icon = "mdi:weather-night";
+                    icon_color = "indigo";
+                    tap_action = {
+                      action = "perform-action";
+                      perform_action = "scene.turn_on";
+                      target.entity_id = "scene.living_room_nightlight";
+                    };
+                  }
+                  {
+                    type = "template";
+                    icon = "mdi:dots-horizontal";
+                    icon_color = "grey";
+                    content = "More";
+                    tap_action = {
+                      action = "navigate";
+                      navigation_path = "/nixos-home/lights?kiosk";
+                    };
+                  }
+                ];
+              }
+            ];
+          }
+        ];
+      };
+
+      # ── Cleaning sub-view (vacuum control + consumable upkeep) ────────────
+      cleaningView = {
+        type = "sections";
+        title = "Cleaning";
+        icon = "mdi:robot-vacuum-variant";
+        path = "cleaning";
+        max_columns = 4;
+        sections = [
+          {
+            type = "grid";
+            cards = [
+              backChip
+              {
+                type = "heading";
+                heading = "Vacuum";
+                heading_style = "title";
+                icon = "mdi:robot-vacuum-variant";
+                badges = [
+                  {
+                    type = "entity";
+                    entity = "vacuum.vaccum";
+                    color = "state";
+                    show_state = true;
+                  }
+                  {
+                    type = "entity";
+                    entity = "sensor.vaccum_battery";
+                    color = "state";
+                  }
+                ];
+              }
+              {
+                type = "tile";
+                entity = "vacuum.vaccum";
+                name = "Vacuum";
+                features_position = "bottom";
+                features = [
+                  {
+                    type = "vacuum-commands";
+                    commands = [
+                      "start_pause"
+                      "return_home"
+                      "locate"
+                      "stop"
+                    ];
+                  }
+                ];
+                grid_options = {
+                  columns = 12;
+                  rows = "auto";
+                };
+              }
+              {
+                type = "heading";
+                heading = "Clean a room";
+                heading_style = "subtitle";
+                icon = "mdi:home-search";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (roomCard "Living Room" "mdi:sofa" "blue" "living_room")
+                  (roomCard "Kitchen" "mdi:stove" "red" "kitchen")
+                  (roomCard "Bedroom" "mdi:bed" "purple" "bedroom")
+                  (roomCard "Office" "mdi:office-building" "amber" "office")
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Schedule";
+                heading_style = "subtitle";
+                icon = "mdi:calendar-clock";
+              }
+              {
+                type = "tile";
+                entity = "input_boolean.vacuum_auto_skip_today";
+                name = "Skip today";
+                grid_options = {
+                  columns = 6;
+                  rows = "auto";
+                };
+              }
+              {
+                type = "custom:mushroom-template-card";
+                primary = "Last auto-run";
+                secondary = "{% set t = states('input_datetime.vacuum_last_auto_run') %}{% if t == '2020-01-01 00:00:00' %}Never{% else %}{{ (t | as_datetime).strftime('%a %b %d %H:%M') }}{% endif %}";
+                icon = "mdi:history";
+                icon_color = "grey";
+              }
+            ];
+          }
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Vacuum upkeep";
+                heading_style = "title";
+                icon = "mdi:wrench";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (gauge {
+                    entity = "sensor.vaccum_battery";
+                    name = "Battery";
+                    min = 0;
+                    max = 100;
+                    severity = {
+                      green = 50;
+                      yellow = 20;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_water_level";
+                    name = "Water";
+                    min = 0;
+                    max = 100;
+                    severity = {
+                      green = 50;
+                      yellow = 20;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_filter_remaining";
+                    name = "Filter";
+                    unit = "h";
+                    min = 0;
+                    max = 360;
+                    severity = {
+                      green = 180;
+                      yellow = 72;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_rolling_brush_remaining";
+                    name = "Roller";
+                    unit = "h";
+                    min = 0;
+                    max = 360;
+                    severity = {
+                      green = 180;
+                      yellow = 72;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_side_brush_remaining";
+                    name = "Side brush";
+                    unit = "h";
+                    min = 0;
+                    max = 180;
+                    severity = {
+                      green = 90;
+                      yellow = 36;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_mopping_cloth_remaining";
+                    name = "Mop";
+                    unit = "h";
+                    min = 0;
+                    max = 180;
+                    severity = {
+                      green = 90;
+                      yellow = 36;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_sensor_remaining";
+                    name = "Sensors";
+                    unit = "h";
+                    min = 0;
+                    max = 60;
+                    severity = {
+                      green = 30;
+                      yellow = 12;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.vaccum_cleaning_tray_remaining";
+                    name = "Tray";
+                    unit = "h";
+                    min = 0;
+                    max = 30;
+                    severity = {
+                      green = 15;
+                      yellow = 6;
+                      red = 0;
+                    };
+                  })
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Humidifier";
+                heading_style = "title";
+                icon = "mdi:air-humidifier";
+              }
+              {
+                type = "tile";
+                entity = "humidifier.humidifier";
+                name = "Humidifier";
+                features_position = "bottom";
+                features = [ { type = "target-humidity"; } ];
+                grid_options = {
+                  columns = 12;
+                  rows = "auto";
+                };
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (gauge {
+                    entity = "sensor.humidifier_filter_lifetime";
+                    name = "Sponge";
+                    unit = "%";
+                    min = 0;
+                    max = 100;
+                    severity = {
+                      green = 50;
+                      yellow = 20;
+                      red = 0;
+                    };
+                  })
+                  (gauge {
+                    entity = "sensor.humidifier_humidity";
+                    name = "Humidity";
+                    unit = "%";
+                    min = 30;
+                    max = 80;
+                  })
+                ];
+              }
+              {
+                type = "tile";
+                entity = "binary_sensor.humidifier_low_water";
+                name = "Tank water";
+                grid_options = {
+                  columns = 6;
+                  rows = "auto";
+                };
+              }
+              {
+                type = "tile";
+                entity = "binary_sensor.humidifier_water_tank_lifted";
+                name = "Tank seated";
+                grid_options = {
+                  columns = 6;
+                  rows = "auto";
+                };
+              }
+            ];
+          }
+        ];
+      };
+
+      # ── Lights sub-view (bulbs, living-room scenes, fairy lights) ─────────
+      lightsView = {
+        type = "sections";
+        title = "Lights";
+        icon = "mdi:lightbulb-multiple";
+        path = "lights";
+        max_columns = 4;
+        sections = [
+          {
+            type = "grid";
+            cards = [
+              backChip
+              {
+                type = "heading";
+                heading = "Bulbs";
+                heading_style = "title";
+                icon = "mdi:lightbulb-group";
+              }
+              {
+                type = "heading";
+                heading = "Living Room";
+                heading_style = "subtitle";
+                icon = "mdi:sofa-outline";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (lightCard {
+                    entity = "light.living_room";
+                    name = "Living Room";
+                    icon = "mdi:sofa-outline";
+                    useLightColor = true;
+                    colorTemp = true;
+                    color = true;
+                    collapsible = false;
+                  })
+                  (lightCard {
+                    entity = "light.smart_led_bulb_2";
+                    name = "Corner Lamp";
+                    icon = "mdi:floor-lamp";
+                    useLightColor = true;
+                  })
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Bedroom";
+                heading_style = "subtitle";
+                icon = "mdi:bed";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (lightCard {
+                    entity = "light.smart_led_bulb";
+                    name = "Bedside";
+                    icon = "mdi:bed-outline";
+                    useLightColor = true;
+                  })
+                  (lightCard {
+                    entity = "light.bedroom_overhead";
+                    name = "Overhead";
+                    icon = "mdi:ceiling-light-outline";
+                  })
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Office";
+                heading_style = "subtitle";
+                icon = "mdi:office-building";
+              }
+              (lightCard {
+                entity = "light.bedroom_overhead_2";
+                name = "Overhead";
+                icon = "mdi:ceiling-light-outline";
+              })
+            ];
+          }
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Living Room Scenes";
+                heading_style = "title";
+                icon = "mdi:palette";
+              }
+              {
+                type = "heading";
+                heading = "Bright";
+                heading_style = "subtitle";
+                icon = "mdi:weather-sunny";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (sceneCard "Bright" "mdi:weather-sunny" "amber" "scene.living_room_bright")
+                  (sceneCard "Energize" "mdi:lightning-bolt" "yellow" "scene.living_room_energize")
+                  (sceneCard "Concentrate" "mdi:brain" "cyan" "scene.living_room_concentrate")
+                  (sceneCard "Natural" "mdi:white-balance-sunny" "white" "scene.living_room_natural_light")
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Warm";
+                heading_style = "subtitle";
+                icon = "mdi:lamp";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (sceneCard "Soho" "mdi:lamp" "deep-orange" "scene.living_room_soho")
+                  (sceneCard "Read" "mdi:book-open-variant" "orange" "scene.living_room_read")
+                  (sceneCard "Relax" "mdi:sofa" "orange" "scene.living_room_relax")
+                  (sceneCard "Candle" "mdi:candle" "deep-orange" "scene.living_room_corner_candle")
+                  (sceneCard "Fireplace" "mdi:fireplace" "red" "scene.living_room_fireplace")
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Dim & Sleep";
+                heading_style = "subtitle";
+                icon = "mdi:weather-night";
+              }
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (sceneCard "Rest" "mdi:bed-outline" "purple" "scene.living_room_rest")
+                  (sceneCard "Night" "mdi:weather-night" "indigo" "scene.living_room_nightlight")
+                  (sceneCard "Moonlight" "mdi:moon-waning-crescent" "indigo" "scene.living_room_moonlight")
+                ];
+              }
+            ];
+          }
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Fairy Lights";
+                heading_style = "title";
+                icon = "mdi:string-lights";
+              }
+              (lightCard {
+                entity = "light.fairy_lights";
+                name = "Fairy";
+                icon = "mdi:string-lights";
+                useLightColor = true;
+                color = true;
+                collapsible = false;
+              })
+              {
+                type = "tile";
+                entity = "select.fairy_lights_preset";
+                name = "Preset";
+                icon = "mdi:palette-swatch";
+                features_position = "bottom";
+                features = [ { type = "select-options"; } ];
+              }
+            ];
+          }
+        ];
+      };
+
+      # ── Week sub-view (two-week multi-person planner) ─────────────────────
+      weekView = {
+        type = "sections";
+        title = "Week";
+        icon = "mdi:calendar-week";
+        path = "week";
+        max_columns = 2;
+        sections = [
+          {
+            type = "grid";
+            column_span = 2;
+            cards = [
+              backChip
+              {
+                type = "custom:atomic-calendar-revive";
+                name = "Two Weeks";
+                maxDaysToShow = 2;
+                maxEventCount = 40;
+                softLimit = 5;
+                showLoader = false;
+                disableEventLink = true;
+                showCalendarName = true;
+                showNoEventsForToday = true;
+                hideFinishedEvents = true;
+                defaultMode = "Planner";
+                eventDateFormat = "ddd MMM D";
+                hideDuplicates = true;
+                showMultiDay = true;
+                showMultiDayEventParts = true;
+                titleLength = 60;
+                plannerRollingWeek = true;
+                compactMode = true;
+                showTimeRemaining = false;
+                hoursOnSameLine = true;
+                language = "en";
+                entities = [
+                  {
+                    entity = "calendar.finn";
+                    name = "Finn";
+                    color = "#f97316";
+                  }
+                  {
+                    entity = "calendar.ciara";
+                    name = "Ciara";
+                    color = "#10b981";
+                  }
+                ];
+                grid_options.columns = "full";
+              }
+            ];
+          }
+        ];
+      };
+
+      homeDashboard = yamlFormat.generate "lovelace-home.yaml" {
+        title = "Home";
+        views = [
+          homeView
+          cleaningView
+          lightsView
+          weekView
+        ];
+      };
+    in
+    {
+      # Single source of truth for this host's frontend resources. Declaring any
+      # of these emits lovelace.resources (yaml resource_mode), so EVERY custom:
+      # card used by any dashboard on iot must be in this list. card-mod MUST stay
+      # here or all card_mod: styling is silently ignored.
+      services.home-assistant.customLovelaceModules = with pkgs.home-assistant-custom-lovelace-modules; [
+        mushroom
+        card-mod
+        auto-entities
+        button-card
+        mini-graph-card
+        clock-weather-card
+        atomic-calendar-revive
+        kiosk-mode # powers the `?kiosk` query param (hides header/sidebar)
+        # + today-card (custom derivation) if the kiosk's today-card is ever
+        #   migrated verbatim; this dashboard swaps it for atomic-calendar-revive.
+      ];
+
+      services.home-assistant.config.lovelace.dashboards.nixos-home = {
+        mode = "yaml";
+        filename = "${homeDashboard}";
+        title = "Home";
+        icon = "mdi:home";
+        show_in_sidebar = true;
+      };
+
+      # Reload on rebuild when the generated dashboard changes (no manual push).
+      systemd.services.home-assistant.reloadTriggers = [ homeDashboard ];
+    };
+}

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -216,15 +216,14 @@ _: {
         }
         // (accentStyle color);
 
-      # Time-aware greeting header for the top of the home view.
-      greetingCard = {
-        type = "custom:mushroom-template-card";
-        primary = "{% set h = now().hour %}{{ 'Good morning' if h < 12 else 'Good afternoon' if h < 18 else 'Good evening' }}";
-        secondary = "{{ now().strftime('%A, %B ') }}{{ now().day }}";
+      # Date + time chip for the top badge row (replaces the old greeting card,
+      # so it no longer pushes the people columns down). Time-aware icon kept.
+      dateTimeBadge = {
+        type = "custom:mushroom-template-badge";
+        content = "{{ now().strftime('%a %-d %b · %-I:%M %p') }}";
         icon = "{% set h = now().hour %}{{ 'mdi:weather-sunset-up' if h < 8 else 'mdi:weather-sunny' if h < 18 else 'mdi:weather-night' }}";
-        icon_color = "{% set h = now().hour %}{{ 'amber' if h < 18 else 'deep-purple' }}";
-      }
-      // (accentStyle "var(--primary-color)");
+        color = "{% set h = now().hour %}{{ 'amber' if h < 18 else 'deep-purple' }}";
+      };
 
       # Glanceable meds toggle: green check when taken, amber prompt otherwise.
       medToggle = entity: label: icon: {
@@ -377,6 +376,7 @@ _: {
         max_columns = 4;
 
         badges = [
+          dateTimeBadge
           {
             type = "entity";
             entity = "sensor.humidifier_humidity";
@@ -435,7 +435,6 @@ _: {
           {
             type = "grid";
             cards = [
-              greetingCard
               {
                 type = "heading";
                 heading = "Finn & Emily";

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -45,6 +45,23 @@ _: {
         hoursOnSameLine = true;
         eventDateFormat = "ddd MMM D";
         language = "en";
+
+        # Colour + typography polish so the agenda reads as a designed card
+        # rather than a flat grey list: titles/bars carry the member's accent,
+        # a "now" line marks the current time, and finished items dim instead
+        # of vanishing so the day still has shape by evening.
+        showColors = true;
+        showCurrentEventLine = true;
+        showProgressBar = true;
+        dimFinishedEvents = true;
+        showRelativeTime = true;
+        eventTitleSize = 95;
+        timeSize = 78;
+        nameColor = color;
+        dayWrapperLineColor = color;
+        eventBarColor = color;
+        defaultColor = "var(--primary-text-color)";
+
         entities = [
           {
             entity = cal;
@@ -55,6 +72,32 @@ _: {
           action = "navigate";
           navigation_path = "/nixos-home/week?kiosk";
         };
+
+        # Rounded accent card with a faint colour wash + tighter padding so the
+        # event rows don't float in dead space.
+        card_mod.style = ''
+          ha-card {
+            border-radius: 18px !important;
+            border: none !important;
+            border-left: 4px solid ${color} !important;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07) !important;
+            background:
+              linear-gradient(135deg, ${color}14 0%, transparent 60%),
+              var(--ha-card-background, var(--card-background-color)) !important;
+            padding: 2px 14px 10px !important;
+          }
+          /* Compact mode sets line-height: 80% on the card, which jams the
+             relative-time row ("(in x hours)") up against the event title.
+             Give each event a little vertical breathing room and a gap
+             between the title row and the time/relative-time row. */
+          .event-right {
+            row-gap: 3px !important;
+          }
+          .event-right-top,
+          .event-right-bottom {
+            line-height: 1.2 !important;
+          }
+        '';
       };
 
       # Back-to-home chip that opens every sub-view (kiosk has no sidebar).
@@ -146,11 +189,90 @@ _: {
         // (if color then { show_color_control = true; } else { })
         // (if collapsible == null then { } else { collapsible_controls = collapsible; });
 
+      # Soft accent card: rounded corners, an accent-coloured left edge and a
+      # gentle shadow. Merged into people/calendar cards so each household member
+      # is colour-coded and the whole board reads as one cohesive set.
+      accentStyle = color: {
+        card_mod.style = ''
+          ha-card {
+            border-radius: 18px !important;
+            border: none !important;
+            border-left: 4px solid ${color} !important;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07) !important;
+          }
+        '';
+      };
+
+      # Per-person presence tile (vertical avatar) in the member's accent colour.
+      personCard =
+        entity: color:
+        {
+          type = "custom:mushroom-person-card";
+          inherit entity;
+          primary_info = "state";
+          secondary_info = "last-changed";
+          icon_type = "entity-picture";
+          layout = "vertical";
+        }
+        // (accentStyle color);
+
+      # Time-aware greeting header for the top of the home view.
+      greetingCard = {
+        type = "custom:mushroom-template-card";
+        primary = "{% set h = now().hour %}{{ 'Good morning' if h < 12 else 'Good afternoon' if h < 18 else 'Good evening' }}";
+        secondary = "{{ now().strftime('%A, %B ') }}{{ now().day }}";
+        icon = "{% set h = now().hour %}{{ 'mdi:weather-sunset-up' if h < 8 else 'mdi:weather-sunny' if h < 18 else 'mdi:weather-night' }}";
+        icon_color = "{% set h = now().hour %}{{ 'amber' if h < 18 else 'deep-purple' }}";
+      }
+      // (accentStyle "var(--primary-color)");
+
+      # Glanceable meds toggle: green check when taken, amber prompt otherwise.
+      medToggle = entity: label: icon: {
+        type = "custom:mushroom-template-card";
+        inherit entity;
+        primary = label;
+        secondary = "{{ 'Taken' if is_state('${entity}', 'on') else 'Not taken' }}";
+        icon = "{{ 'mdi:check-circle' if is_state('${entity}', 'on') else '${icon}' }}";
+        icon_color = "{{ 'green' if is_state('${entity}', 'on') else 'orange' }}";
+        tap_action.action = "toggle";
+      };
+
       # ── Finn-only cards ───────────────────────────────────────────────────
       # These live on the separate Finn dashboard (nixos-finn), not the shared
-      # iPad kiosk: a pending-meds alert, Finn's chore to-do list, and the
-      # vacuum/humidifier consumable warning chips (the upkeep work is now
-      # ChoreOps chores assigned to specific people, so it's off the shared view).
+      # iPad kiosk: a pending-meds alert, Finn's chore to-do list, the personal
+      # fridge-nudges banner, and the vacuum/humidifier consumable warning chips
+      # (the upkeep work is now ChoreOps chores assigned to specific people, so
+      # it's off the shared view).
+
+      # Personal reminder banner: bulleted nudges from sensor.fridge_nudges,
+      # hidden entirely when there's nothing to say. Amber accent + glowing
+      # bullets so it reads as a soft prompt rather than an alert.
+      nudgesCard = {
+        type = "markdown";
+        content = ''
+          {% set lines = state_attr('sensor.fridge_nudges', 'lines') or [] %}{% if lines %}{% for line in lines %}- {{ line }}
+          {% endfor %}{% endif %}'';
+        visibility = [
+          {
+            condition = "state";
+            entity = "sensor.fridge_nudges";
+            state_not = [
+              ""
+              "unknown"
+              "unavailable"
+            ];
+          }
+        ];
+        card_mod.style = {
+          "." = ''
+            ha-card {   background: linear-gradient(135deg, rgba(245,158,11,0.10), rgba(245,158,11,0.02)) !important;   border-radius: 16px !important;   border: none !important;   border-left: 4px solid var(--warning-color, #f59e0b) !important;   box-shadow: 0 2px 10px rgba(0,0,0,0.06) !important; }
+          '';
+          "ha-markdown$" = ''
+            .markdown-body { padding: 2px 6px; } ul { padding-left: 0; margin: 0; list-style: none; } li {   font-size: 1.25em;   font-weight: 500;   line-height: 1.45;   padding: 8px 4px 8px 32px;   position: relative;   letter-spacing: -0.005em;   border-bottom: 1px solid rgba(245,158,11,0.12); } li:last-child { border-bottom: none; } li::before {   content: "";   position: absolute;   left: 8px;   top: 0.85em;   width: 10px;   height: 10px;   border-radius: 50%;   background: var(--warning-color, #f59e0b);   box-shadow: 0 0 10px rgba(245,158,11,0.5); }
+          '';
+        };
+      };
+
       medsCard = {
         type = "conditional";
         conditions = [
@@ -256,11 +378,6 @@ _: {
 
         badges = [
           {
-            type = "custom:mushroom-template-badge";
-            content = "{{ now().strftime('%a %b %d') }}";
-            icon = "mdi:calendar";
-          }
-          {
             type = "entity";
             entity = "sensor.humidifier_humidity";
             name = "Humidity";
@@ -314,47 +431,16 @@ _: {
         ];
 
         sections = [
-          # ── Fridge nudges (LLM-written reminders; hidden when empty) ───────
-          {
-            type = "grid";
-            column_span = 4;
-            cards = [
-              {
-                type = "markdown";
-                content = ''
-                  {% set lines = state_attr('sensor.fridge_nudges', 'lines') or [] %}{% if lines %}{% for line in lines %}- {{ line }}
-                  {% endfor %}{% endif %}'';
-                visibility = [
-                  {
-                    condition = "state";
-                    entity = "sensor.fridge_nudges";
-                    state_not = [
-                      ""
-                      "unknown"
-                      "unavailable"
-                    ];
-                  }
-                ];
-                card_mod.style = {
-                  "." = ''
-                    ha-card {   background: linear-gradient(135deg, rgba(245,158,11,0.10), rgba(245,158,11,0.02)) !important;   border-radius: 16px !important;   border: none !important;   border-left: 4px solid var(--warning-color, #f59e0b) !important;   box-shadow: 0 2px 10px rgba(0,0,0,0.06) !important; }
-                  '';
-                  "ha-markdown$" = ''
-                    .markdown-body { padding: 2px 6px; } ul { padding-left: 0; margin: 0; list-style: none; } li {   font-size: 1.25em;   font-weight: 500;   line-height: 1.45;   padding: 8px 4px 8px 32px;   position: relative;   letter-spacing: -0.005em;   border-bottom: 1px solid rgba(245,158,11,0.12); } li:last-child { border-bottom: none; } li::before {   content: "";   position: absolute;   left: 8px;   top: 0.85em;   width: 10px;   height: 10px;   border-radius: 50%;   background: var(--warning-color, #f59e0b);   box-shadow: 0 0 10px rgba(245,158,11,0.5); }
-                  '';
-                };
-              }
-            ];
-          }
-
-          # ── Finn & Emily: presence + Finn's calendar ──────────────────────
+          # ── Finn & Emily: greeting, presence + Finn's calendar ────────────
           {
             type = "grid";
             cards = [
+              greetingCard
               {
                 type = "heading";
                 heading = "Finn & Emily";
                 heading_style = "title";
+                icon = "mdi:account-multiple";
                 badges = [
                   {
                     type = "entity";
@@ -366,20 +452,13 @@ _: {
                 ];
               }
               {
-                type = "custom:mushroom-person-card";
-                entity = "person.finn";
-                fill_container = false;
-                secondary_info = "last-changed";
-                primary_info = "state";
-                icon_type = "entity-picture";
-              }
-              {
-                type = "custom:mushroom-person-card";
-                entity = "person.emily";
-                fill_container = false;
-                secondary_info = "last-changed";
-                primary_info = "state";
-                icon_type = "entity-picture";
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (personCard "person.finn" "#f97316")
+                  (personCard "person.emily" "#f43f5e")
+                ];
               }
               (calendarToday "calendar.finn" "#f97316")
             ];
@@ -393,6 +472,7 @@ _: {
                 type = "heading";
                 heading = "Ciara & Holland";
                 heading_style = "title";
+                icon = "mdi:account-multiple";
                 badges = [
                   {
                     type = "entity";
@@ -404,18 +484,13 @@ _: {
                 ];
               }
               {
-                type = "custom:mushroom-person-card";
-                entity = "person.ciara";
-                primary_info = "state";
-                secondary_info = "last-changed";
-                icon_type = "entity-picture";
-              }
-              {
-                type = "custom:mushroom-person-card";
-                entity = "person.holland";
-                primary_info = "state";
-                secondary_info = "last-changed";
-                icon_type = "entity-picture";
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  (personCard "person.ciara" "#10b981")
+                  (personCard "person.holland" "#a855f7")
+                ];
               }
               (calendarToday "calendar.ciara" "#10b981")
               # Holland's calendar — entity arrives later; the card stays empty
@@ -1188,6 +1263,10 @@ _: {
                 compactMode = true;
                 showTimeRemaining = false;
                 hoursOnSameLine = true;
+                showColors = true;
+                dimFinishedEvents = true;
+                eventTitleSize = 95;
+                timeSize = 80;
                 language = "en";
                 entities = [
                   {
@@ -1235,6 +1314,12 @@ _: {
           }
         ];
         sections = [
+          # ── Reminders: personal fridge nudges (hidden when empty) ─────────
+          {
+            type = "grid";
+            column_span = 2;
+            cards = [ nudgesCard ];
+          }
           # ── Meds: alert (when pending) + mark-taken toggles ───────────────
           {
             type = "grid";
@@ -1251,18 +1336,8 @@ _: {
                 columns = 2;
                 square = false;
                 cards = [
-                  {
-                    type = "tile";
-                    entity = "input_boolean.morning_meds_taken";
-                    name = "Morning";
-                    icon = "mdi:weather-sunny";
-                  }
-                  {
-                    type = "tile";
-                    entity = "input_boolean.night_meds_taken";
-                    name = "Night";
-                    icon = "mdi:weather-night";
-                  }
+                  (medToggle "input_boolean.morning_meds_taken" "Morning" "mdi:weather-sunny")
+                  (medToggle "input_boolean.night_meds_taken" "Night" "mdi:weather-night")
                 ];
               }
             ];

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -18,6 +18,13 @@
 # cleaning, lights and week sub-views (all declarative here). The Reorder chip
 # crosses to the separate `nixos-reorder` dashboard (same catalog.json generator,
 # so not a second source of truth); that dashboard has a Back chip home.
+#
+# The home view leads with a "Household" section that surfaces the shared
+# ChoreOps state — a points leaderboard + a "needs doing" strip — which taps
+# through to ChoreOps's own auto-managed `cod-chores` storage dashboard for the
+# actionable claim/approve UI. Those links intentionally OMIT `?kiosk` so HA's
+# chrome (sidebar + per-person view tabs) stays available on cod-chores: it is
+# integration-managed, so we never edit it to add our own back/nav chrome.
 # `?kiosk` chrome (hidden header/sidebar) is the kiosk-mode plugin, declared below.
 # The storage `main-home` dashboard is left intact as a fallback.
 _: {
@@ -369,6 +376,136 @@ _: {
         hide_section_headers = true;
       };
 
+      # ── ChoreOps (shared household) ───────────────────────────────────────
+      # ChoreOps runs the apartment's shared chores + points. The actionable
+      # claim/approve UI lives on the integration's own auto-managed `cod-chores`
+      # storage dashboard (per-person pages, kept in sync by the integration and
+      # built from custom:button-card + custom:auto-entities — both already in
+      # customLovelaceModules, so it renders under this host's yaml resource mode).
+      # The shared kitchen view carries only a glanceable standings + what's-due
+      # summary that taps through to that dashboard.
+
+      # One roommate's standing: points balance + how many chores are due/overdue
+      # right now, tinted red when anything is overdue. Taps into that person's
+      # page on cod-chores to claim/complete.
+      leaderCard =
+        user: name: color:
+        {
+          type = "custom:mushroom-template-card";
+          primary = name;
+          secondary = "{{ states('sensor.${user}_choreops_points') | int(0) }} pts · {% set d = (state_attr('sensor.${user}_choreops_chores', 'chore_stat_current_due_today') | int(0)) + (state_attr('sensor.${user}_choreops_chores', 'chore_stat_current_overdue') | int(0)) %}{{ (d ~ ' to do') if d > 0 else 'all done' }}";
+          icon = "mdi:star-circle";
+          icon_color = "{% set o = state_attr('sensor.${user}_choreops_chores', 'chore_stat_current_overdue') | int(0) %}{{ 'red' if o > 0 else '${color}' }}";
+          badge_icon = "{% set o = state_attr('sensor.${user}_choreops_chores', 'chore_stat_current_overdue') | int(0) %}{{ 'mdi:alert-circle' if o > 0 else '' }}";
+          badge_color = "red";
+          # No ?kiosk: the auto-managed cod-chores dashboard is left untouched, so
+          # we rely on HA's own chrome (sidebar + per-person view tabs) there for
+          # claim/approve, switching roommates, and getting back to Home.
+          tap_action = {
+            action = "navigate";
+            navigation_path = "/cod-chores/${user}";
+          };
+        }
+        // (accentStyle color);
+
+      # "Needs doing" chips: every chore that needs doing TODAY — overdue or
+      # due today — deduped by chore name across the household (shared chores show
+      # up per-person). "Due today" is gated on the sensor's own due_date (local
+      # date <= today): a chore that's merely pending but not due for days/weeks
+      # (or has no deadline at all, due_date null) is left off, so the strip
+      # matches the leaderboard's due_today+overdue "to do" count rather than
+      # listing the whole backlog. Each is labelled + colour-coded by owner (the
+      # per-person accent scheme, keyed off the sensor's user_name) and TAPS TO COMPLETE
+      # it — pressing the chore's own per-owner button (claim if present, else
+      # approve), exactly the button.press action ChoreOps's own cod-chores card
+      # fires, so the chore is marked done + points awarded to the current owner.
+      # A confirmation guards against accidental taps on the shared kiosk. Only
+      # chores that expose a button are listed; hidden entirely when none remain.
+      needsDoingChips = {
+        type = "custom:auto-entities";
+        card_param = "chips";
+        show_empty = false;
+        card = {
+          type = "custom:mushroom-chips-card";
+          alignment = "start";
+        };
+        filter.template = ''
+          {%- set colors = {'Finn': '#f97316', 'Ciara': '#10b981', 'Holland': '#a855f7'} -%}
+          {%- set today = now().date() -%}
+          {%- set ns = namespace(chips=[], seen=[]) -%}
+          {%- for s in states.sensor | selectattr('entity_id', 'search', '_choreops_chore_status_') -%}
+            {%- set cn = s.attributes.chore_name | default("") -%}
+            {%- set btn = s.attributes.claim_button_eid or s.attributes.approve_button_eid -%}
+            {%- set dd = s.attributes.due_date -%}
+            {%- set due_today = dd and (dd | as_datetime | as_local).date() <= today -%}
+            {%- if s.state in ['pending', 'overdue'] and due_today and cn and btn and cn not in ns.seen -%}
+              {%- set ns.seen = ns.seen + [cn] -%}
+              {%- set owner = s.attributes.user_name | default("") -%}
+              {%- set chip = {
+                'type': 'template',
+                'icon': s.attributes.icon | default('mdi:checkbox-marked-circle-outline'),
+                'icon_color': colors.get(owner, 'grey'),
+                'content': (cn ~ (' · ' ~ owner if owner else "")),
+                'tap_action': {
+                  'action': 'perform-action',
+                  'perform_action': 'button.press',
+                  'target': {'entity_id': btn},
+                  'confirmation': {'text': ('Complete ' ~ cn ~ (' for ' ~ owner if owner else "") ~ '?')}
+                }
+              } -%}
+              {%- set ns.chips = ns.chips + [chip] -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {{ ns.chips[:12] | tojson }}
+        '';
+      };
+
+      # Combined "today" agenda across the residents' calendars + the shared
+      # household calendar. Same atomic-calendar-revive polish as calendarToday
+      # but multi-entity, with the calendar name shown so events read as "whose".
+      sharedAgenda = entities: accent: {
+        type = "custom:atomic-calendar-revive";
+        name = "Today";
+        maxDaysToShow = 1;
+        maxEventCount = 12;
+        showLoader = false;
+        showDate = false;
+        showLocation = false;
+        showCalendarName = true;
+        showNoEventsForToday = true;
+        hideFinishedEvents = true;
+        disableEventLink = true;
+        compactMode = true;
+        hoursOnSameLine = true;
+        eventDateFormat = "ddd MMM D";
+        language = "en";
+        showColors = true;
+        showCurrentEventLine = true;
+        showProgressBar = true;
+        dimFinishedEvents = true;
+        showRelativeTime = true;
+        eventTitleSize = 95;
+        timeSize = 78;
+        defaultColor = "var(--primary-text-color)";
+        inherit entities;
+        tap_action = {
+          action = "navigate";
+          navigation_path = "/nixos-home/week?kiosk";
+        };
+        card_mod.style = ''
+          ha-card {
+            border-radius: 18px !important;
+            border: none !important;
+            border-left: 4px solid ${accent} !important;
+            box-shadow: 0 2px 12px rgba(0, 0, 0, 0.07) !important;
+            padding: 2px 14px 10px !important;
+          }
+          .event-right { row-gap: 3px !important; }
+          .event-right-top,
+          .event-right-bottom { line-height: 1.2 !important; }
+        '';
+      };
+
       homeView = {
         type = "sections";
         title = "Home";
@@ -431,15 +568,15 @@ _: {
         ];
 
         sections = [
-          # ── Finn & Emily: greeting, presence + Finn's calendar ────────────
+          # ── Today: who's home + the shared agenda ─────────────────────────
           {
             type = "grid";
             cards = [
               {
                 type = "heading";
-                heading = "Finn & Emily";
+                heading = "Today";
                 heading_style = "title";
-                icon = "mdi:account-multiple";
+                icon = "mdi:account-group";
                 badges = [
                   {
                     type = "entity";
@@ -448,31 +585,6 @@ _: {
                     entity = "sensor.nougat_battery_level";
                     color = "state";
                   }
-                ];
-              }
-              {
-                type = "grid";
-                columns = 2;
-                square = false;
-                cards = [
-                  (personCard "person.finn" "#f97316")
-                  (personCard "person.emily" "#f43f5e")
-                ];
-              }
-              (calendarToday "calendar.finn" "#f97316")
-            ];
-          }
-
-          # ── Ciara & Holland: presence + their calendars + shopping list ───
-          {
-            type = "grid";
-            cards = [
-              {
-                type = "heading";
-                heading = "Ciara & Holland";
-                heading_style = "title";
-                icon = "mdi:account-multiple";
-                badges = [
                   {
                     type = "entity";
                     show_state = true;
@@ -487,20 +599,74 @@ _: {
                 columns = 2;
                 square = false;
                 cards = [
+                  (personCard "person.finn" "#f97316")
                   (personCard "person.ciara" "#10b981")
                   (personCard "person.holland" "#a855f7")
+                  (personCard "person.emily" "#f43f5e")
                 ];
               }
-              (calendarToday "calendar.ciara" "#10b981")
-              # Holland's calendar — entity arrives later; the card stays empty
-              # until calendar.holland exists.
-              (calendarToday "calendar.holland" "#a855f7")
+              (sharedAgenda [
+                {
+                  entity = "calendar.finn";
+                  color = "#f97316";
+                }
+                {
+                  entity = "calendar.ciara";
+                  color = "#10b981";
+                }
+                {
+                  entity = "calendar.holland";
+                  color = "#a855f7";
+                }
+              ] "#64748b")
+            ];
+          }
+
+          # ── Household: chore standings + tap-to-complete ─────────────────
+          # The apartment's shared chores live in ChoreOps. A points leaderboard
+          # (each taps to that person's cod-chores page) sits above a "needs
+          # doing" strip whose chips complete the chore inline on tap.
+          {
+            type = "grid";
+            cards = [
               {
-                display_order = "none";
-                type = "todo-list";
-                entity = "todo.foodtown";
-                hide_completed = true;
-                hide_section_headers = true;
+                type = "heading";
+                heading = "Household";
+                heading_style = "title";
+                icon = "mdi:trophy";
+              }
+              {
+                type = "grid";
+                columns = 3;
+                square = false;
+                cards = [
+                  (leaderCard "finn" "Finn" "#f97316")
+                  (leaderCard "ciara" "Ciara" "#10b981")
+                  (leaderCard "holland" "Holland" "#a855f7")
+                ];
+              }
+              {
+                type = "heading";
+                heading = "Needs doing";
+                heading_style = "subtitle";
+                icon = "mdi:clipboard-list-outline";
+              }
+              needsDoingChips
+              {
+                type = "custom:mushroom-chips-card";
+                alignment = "start";
+                chips = [
+                  {
+                    type = "template";
+                    icon = "mdi:clipboard-check-multiple-outline";
+                    icon_color = "teal";
+                    content = "All chores";
+                    tap_action = {
+                      action = "navigate";
+                      navigation_path = "/cod-chores";
+                    };
+                  }
+                ];
               }
             ];
           }
@@ -579,6 +745,19 @@ _: {
                     };
                   }
                 ];
+              }
+              {
+                type = "heading";
+                heading = "Shopping list";
+                heading_style = "subtitle";
+                icon = "mdi:cart-outline";
+              }
+              {
+                display_order = "none";
+                type = "todo-list";
+                entity = "todo.foodtown";
+                hide_completed = true;
+                hide_section_headers = true;
               }
               {
                 type = "media-control";
@@ -1281,7 +1460,6 @@ _: {
                     name = "Ciara";
                     color = "#10b981";
                   }
-                  # Holland's calendar — entity arrives later.
                   {
                     entity = "calendar.holland";
                     name = "Holland";

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -212,7 +212,7 @@ _: {
           primary_info = "state";
           secondary_info = "last-changed";
           icon_type = "entity-picture";
-          layout = "vertical";
+          layout = "horizontal";
         }
         // (accentStyle color);
 

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -19,10 +19,12 @@
 # crosses to the separate `nixos-reorder` dashboard (same catalog.json generator,
 # so not a second source of truth); that dashboard has a Back chip home.
 #
-# The home view leads with a "Household" section that surfaces the shared
-# ChoreOps state — a points leaderboard + a "needs doing" strip — which taps
-# through to ChoreOps's own auto-managed `cod-chores` storage dashboard for the
-# actionable claim/approve UI. Those links intentionally OMIT `?kiosk` so HA's
+# The home view's "Today" column carries the shared ChoreOps state — a points
+# leaderboard + a "needs doing" strip — folded in directly under the day's
+# agenda (the chores are due today, so they read as part of "today" rather than
+# floating in their own auto-placed column). Those cards tap through to
+# ChoreOps's own auto-managed `cod-chores` storage dashboard for the actionable
+# claim/approve UI. Those links intentionally OMIT `?kiosk` so HA's
 # chrome (sidebar + per-person view tabs) stays available on cod-chores: it is
 # integration-managed, so we never edit it to add our own back/nav chrome.
 # `?kiosk` chrome (hidden header/sidebar) is the kiosk-mode plugin, declared below.
@@ -409,13 +411,15 @@ _: {
         // (accentStyle color);
 
       # "Needs doing" chips: every chore that needs doing TODAY — overdue or
-      # due today — deduped by chore name across the household (shared chores show
-      # up per-person). "Due today" is gated on the sensor's own due_date (local
-      # date <= today): a chore that's merely pending but not due for days/weeks
-      # (or has no deadline at all, due_date null) is left off, so the strip
-      # matches the leaderboard's due_today+overdue "to do" count rather than
-      # listing the whole backlog. Each is labelled + colour-coded by owner (the
-      # per-person accent scheme, keyed off the sensor's user_name) and TAPS TO COMPLETE
+      # due today — deduped by chore name across the household (one chip per chore,
+      # first matching per-person status sensor wins). "Due today" is gated on the
+      # sensor's own due_date (local date <= today): a chore that's merely pending
+      # but not due for days/weeks (or has no deadline at all, due_date null) is
+      # left off, so the strip matches the leaderboard's due_today+overdue "to do"
+      # count rather than listing the whole backlog. Solo chores are labelled +
+      # colour-coded by owner (the per-person accent scheme, keyed off the sensor's
+      # user_name); shared chores (assigned_user_names > 1) read "· Everyone" in
+      # neutral grey rather than collapsing onto whichever assignee sorts first. Each TAPS TO COMPLETE
       # it — pressing the chore's own per-owner button (claim if present, else
       # approve), exactly the button.press action ChoreOps's own cod-chores card
       # fires, so the chore is marked done + points awarded to the current owner.
@@ -440,17 +444,21 @@ _: {
             {%- set due_today = dd and (dd | as_datetime | as_local).date() <= today -%}
             {%- if s.state in ['pending', 'overdue'] and due_today and cn and btn and cn not in ns.seen -%}
               {%- set ns.seen = ns.seen + [cn] -%}
+              {%- set assignees = s.attributes.assigned_user_names | default([]) -%}
+              {%- set shared = assignees | length > 1 -%}
               {%- set owner = s.attributes.user_name | default("") -%}
+              {%- set label = 'Everyone' if shared else owner -%}
+              {%- set chip_color = 'grey' if shared else colors.get(owner, 'grey') -%}
               {%- set chip = {
                 'type': 'template',
                 'icon': s.attributes.icon | default('mdi:checkbox-marked-circle-outline'),
-                'icon_color': colors.get(owner, 'grey'),
-                'content': (cn ~ (' · ' ~ owner if owner else "")),
+                'icon_color': chip_color,
+                'content': (cn ~ (' · ' ~ label if label else "")),
                 'tap_action': {
                   'action': 'perform-action',
                   'perform_action': 'button.press',
                   'target': {'entity_id': btn},
-                  'confirmation': {'text': ('Complete ' ~ cn ~ (' for ' ~ owner if owner else "") ~ '?')}
+                  'confirmation': {'text': ('Complete ' ~ cn ~ (' for ' ~ label if label else "") ~ '?')}
                 }
               } -%}
               {%- set ns.chips = ns.chips + [chip] -%}
@@ -568,7 +576,7 @@ _: {
         ];
 
         sections = [
-          # ── Today: who's home + the shared agenda ─────────────────────────
+          # ── Today: who's home + the shared agenda + today's chores ────────
           {
             type = "grid";
             cards = [
@@ -619,16 +627,13 @@ _: {
                   color = "#a855f7";
                 }
               ] "#64748b")
-            ];
-          }
 
-          # ── Household: chore standings + tap-to-complete ─────────────────
-          # The apartment's shared chores live in ChoreOps. A points leaderboard
-          # (each taps to that person's cod-chores page) sits above a "needs
-          # doing" strip whose chips complete the chore inline on tap.
-          {
-            type = "grid";
-            cards = [
+              # ── Household: chore standings + tap-to-complete ───────────────
+              # Folded into the Today column on purpose: these chores are due
+              # TODAY, so they belong directly under the day's agenda rather than
+              # floating in their own auto-placed column. A points leaderboard
+              # (each taps to that person's cod-chores page) sits above a "needs
+              # doing" strip whose chips complete the chore inline on tap.
               {
                 type = "heading";
                 heading = "Household";

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -591,7 +591,10 @@ _: {
                   {
                     condition = "state";
                     entity = "media_player.living_room";
-                    state_not = "off";
+                    state = [
+                      "playing"
+                      "paused"
+                    ];
                   }
                 ];
               }

--- a/modules/iot/dashboard-home.nix
+++ b/modules/iot/dashboard-home.nix
@@ -146,6 +146,108 @@ _: {
         // (if color then { show_color_control = true; } else { })
         // (if collapsible == null then { } else { collapsible_controls = collapsible; });
 
+      # ── Finn-only cards ───────────────────────────────────────────────────
+      # These live on the separate Finn dashboard (nixos-finn), not the shared
+      # iPad kiosk: a pending-meds alert, Finn's chore to-do list, and the
+      # vacuum/humidifier consumable warning chips (the upkeep work is now
+      # ChoreOps chores assigned to specific people, so it's off the shared view).
+      medsCard = {
+        type = "conditional";
+        conditions = [
+          {
+            entity = "binary_sensor.meds_needed";
+            state = "on";
+          }
+        ];
+        card = {
+          type = "markdown";
+          card_mod.style = {
+            "." = ''
+              ha-card {
+                background: linear-gradient(135deg, #c62828 0%, #b71c1c 100%);
+                color: #fff;
+                --card-primary-text-color: #fff;
+                --card-secondary-text-color: rgba(255, 255, 255, 0.85);
+                --ha-card-border-radius: 16px;
+                padding: 20px 24px;
+                font-size: 1.3em;
+                border: 2px solid rgba(255, 255, 255, 0.15);
+                box-shadow: 0 8px 32px rgba(183, 28, 28, 0.4);
+              }
+            '';
+            "ha-markdown$" = ''
+              .markdown-body h2 { margin: 0 0 8px 0; }
+              .markdown-body p { margin: 0; }
+            '';
+          };
+          content = ''
+            {% set morning = state_attr('binary_sensor.meds_needed', 'morning_pending') %}
+            {% set night   = state_attr('binary_sensor.meds_needed', 'night_pending') %}
+            {% if morning and night %}
+            ## <ha-icon icon="mdi:alert-circle"></ha-icon> Morning & Night Meds
+            **Both** still need to be taken today.
+            {% elif morning %}
+            ## <ha-icon icon="mdi:alert-circle"></ha-icon> Morning Meds
+            Not taken yet today.
+            {% elif night %}
+            ## <ha-icon icon="mdi:alert-circle"></ha-icon> Night Meds
+            Not taken yet tonight.
+            {% endif %}
+          '';
+        };
+      };
+
+      consumableChips = {
+        type = "custom:auto-entities";
+        card_param = "chips";
+        show_empty = false;
+        card = {
+          type = "custom:mushroom-chips-card";
+          alignment = "start";
+        };
+        filter.template = ''
+          [
+          {%- set entries = [
+            ('sensor.vaccum_filter_remaining', 'Filter', 'mdi:air-filter'),
+            ('sensor.vaccum_rolling_brush_remaining', 'Roller', 'mdi:rotate-3d-variant'),
+            ('sensor.vaccum_side_brush_remaining', 'Side brush', 'mdi:fan'),
+            ('sensor.vaccum_mopping_cloth_remaining', 'Mop', 'mdi:waves'),
+            ('sensor.vaccum_sensor_remaining', 'Sensors', 'mdi:eye-outline'),
+            ('sensor.vaccum_cleaning_tray_remaining', 'Tray', 'mdi:wiper'),
+          ] -%}
+          {%- for s, label, icon in entries -%}
+            {%- set t = state_attr(s, 'total_life_hours') | float(0) -%}
+            {%- if t > 0 -%}
+              {%- set pct = (states(s) | float(0) / t * 100) | int -%}
+              {%- if pct < 20 -%}
+                {'entity': '{{ s }}', 'type': 'template', 'icon': '{{ icon }}', 'icon_color': 'orange', 'content': '{{ label }} {{ pct }}%', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
+              {%- endif -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- set sponge = states('sensor.humidifier_filter_lifetime') | float(100) -%}
+          {%- if sponge < 30 -%}
+            {'entity': 'sensor.humidifier_filter_lifetime', 'type': 'template', 'icon': 'mdi:air-filter', 'icon_color': 'orange', 'content': 'Sponge {{ sponge | int }}%', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
+          {%- endif -%}
+          {%- if is_state('binary_sensor.humidifier_low_water', 'on') -%}
+            {'entity': 'binary_sensor.humidifier_low_water', 'type': 'template', 'icon': 'mdi:water-alert', 'icon_color': 'red', 'content': 'Tank empty', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
+          {%- endif -%}
+          {%- set err = states('sensor.vaccum_error_message') | string -%}
+          {%- if err and err | length > 0 and err != 'unknown' and err != 'unavailable' -%}
+            {'entity': 'sensor.vaccum_error_message', 'type': 'template', 'icon': 'mdi:robot-vacuum-alert', 'icon_color': 'red', 'content': '{{ err }}', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}}
+          {%- endif -%}
+          ]
+        '';
+      };
+
+      choresTodo = {
+        display_order = "duedate_asc";
+        type = "todo-list";
+        entity = "todo.chores";
+        hide_create = false;
+        hide_completed = true;
+        hide_section_headers = true;
+      };
+
       homeView = {
         type = "sections";
         title = "Home";
@@ -212,107 +314,6 @@ _: {
         ];
 
         sections = [
-          # ── Meds alert (only renders when a dose is pending) ──────────────
-          {
-            type = "grid";
-            cards = [
-              {
-                type = "conditional";
-                conditions = [
-                  {
-                    entity = "binary_sensor.meds_needed";
-                    state = "on";
-                  }
-                ];
-                card = {
-                  type = "markdown";
-                  card_mod.style = {
-                    "." = ''
-                      ha-card {
-                        background: linear-gradient(135deg, #c62828 0%, #b71c1c 100%);
-                        color: #fff;
-                        --card-primary-text-color: #fff;
-                        --card-secondary-text-color: rgba(255, 255, 255, 0.85);
-                        --ha-card-border-radius: 16px;
-                        padding: 20px 24px;
-                        font-size: 1.3em;
-                        border: 2px solid rgba(255, 255, 255, 0.15);
-                        box-shadow: 0 8px 32px rgba(183, 28, 28, 0.4);
-                      }
-                    '';
-                    "ha-markdown$" = ''
-                      .markdown-body h2 { margin: 0 0 8px 0; }
-                      .markdown-body p { margin: 0; }
-                    '';
-                  };
-                  content = ''
-                    {% set morning = state_attr('binary_sensor.meds_needed', 'morning_pending') %}
-                    {% set night   = state_attr('binary_sensor.meds_needed', 'night_pending') %}
-                    {% if morning and night %}
-                    ## <ha-icon icon="mdi:alert-circle"></ha-icon> Morning & Night Meds
-                    **Both** still need to be taken today.
-                    {% elif morning %}
-                    ## <ha-icon icon="mdi:alert-circle"></ha-icon> Morning Meds
-                    Not taken yet today.
-                    {% elif night %}
-                    ## <ha-icon icon="mdi:alert-circle"></ha-icon> Night Meds
-                    Not taken yet tonight.
-                    {% endif %}
-                  '';
-                };
-              }
-            ];
-          }
-
-          # ── Vacuum / humidifier consumable warnings (auto-populated chips) ─
-          {
-            type = "grid";
-            column_span = 4;
-            cards = [
-              {
-                type = "custom:auto-entities";
-                card_param = "chips";
-                show_empty = false;
-                card = {
-                  type = "custom:mushroom-chips-card";
-                  alignment = "start";
-                };
-                filter.template = ''
-                  [
-                  {%- set entries = [
-                    ('sensor.vaccum_filter_remaining', 'Filter', 'mdi:air-filter'),
-                    ('sensor.vaccum_rolling_brush_remaining', 'Roller', 'mdi:rotate-3d-variant'),
-                    ('sensor.vaccum_side_brush_remaining', 'Side brush', 'mdi:fan'),
-                    ('sensor.vaccum_mopping_cloth_remaining', 'Mop', 'mdi:waves'),
-                    ('sensor.vaccum_sensor_remaining', 'Sensors', 'mdi:eye-outline'),
-                    ('sensor.vaccum_cleaning_tray_remaining', 'Tray', 'mdi:wiper'),
-                  ] -%}
-                  {%- for s, label, icon in entries -%}
-                    {%- set t = state_attr(s, 'total_life_hours') | float(0) -%}
-                    {%- if t > 0 -%}
-                      {%- set pct = (states(s) | float(0) / t * 100) | int -%}
-                      {%- if pct < 20 -%}
-                        {'entity': '{{ s }}', 'type': 'template', 'icon': '{{ icon }}', 'icon_color': 'orange', 'content': '{{ label }} {{ pct }}%', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
-                      {%- endif -%}
-                    {%- endif -%}
-                  {%- endfor -%}
-                  {%- set sponge = states('sensor.humidifier_filter_lifetime') | float(100) -%}
-                  {%- if sponge < 30 -%}
-                    {'entity': 'sensor.humidifier_filter_lifetime', 'type': 'template', 'icon': 'mdi:air-filter', 'icon_color': 'orange', 'content': 'Sponge {{ sponge | int }}%', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
-                  {%- endif -%}
-                  {%- if is_state('binary_sensor.humidifier_low_water', 'on') -%}
-                    {'entity': 'binary_sensor.humidifier_low_water', 'type': 'template', 'icon': 'mdi:water-alert', 'icon_color': 'red', 'content': 'Tank empty', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}},
-                  {%- endif -%}
-                  {%- set err = states('sensor.vaccum_error_message') | string -%}
-                  {%- if err and err | length > 0 and err != 'unknown' and err != 'unavailable' -%}
-                    {'entity': 'sensor.vaccum_error_message', 'type': 'template', 'icon': 'mdi:robot-vacuum-alert', 'icon_color': 'red', 'content': '{{ err }}', 'tap_action': {'action': 'navigate', 'navigation_path': '/nixos-home/cleaning?kiosk'}}
-                  {%- endif -%}
-                  ]
-                '';
-              }
-            ];
-          }
-
           # ── Fridge nudges (LLM-written reminders; hidden when empty) ───────
           {
             type = "grid";
@@ -346,13 +347,13 @@ _: {
             ];
           }
 
-          # ── Finn: presence, today's calendar, chores ──────────────────────
+          # ── Finn & Emily: presence + Finn's calendar ──────────────────────
           {
             type = "grid";
             cards = [
               {
                 type = "heading";
-                heading = "Finn";
+                heading = "Finn & Emily";
                 heading_style = "title";
                 badges = [
                   {
@@ -381,24 +382,16 @@ _: {
                 icon_type = "entity-picture";
               }
               (calendarToday "calendar.finn" "#f97316")
-              {
-                display_order = "duedate_asc";
-                type = "todo-list";
-                entity = "todo.chores";
-                hide_create = false;
-                hide_completed = true;
-                hide_section_headers = true;
-              }
             ];
           }
 
-          # ── Ciara: presence, today's calendar, shopping list ──────────────
+          # ── Ciara & Holland: presence + their calendars + shopping list ───
           {
             type = "grid";
             cards = [
               {
                 type = "heading";
-                heading = "Ciara";
+                heading = "Ciara & Holland";
                 heading_style = "title";
                 badges = [
                   {
@@ -425,6 +418,9 @@ _: {
                 icon_type = "entity-picture";
               }
               (calendarToday "calendar.ciara" "#10b981")
+              # Holland's calendar — entity arrives later; the card stays empty
+              # until calendar.holland exists.
+              (calendarToday "calendar.holland" "#a855f7")
               {
                 display_order = "none";
                 type = "todo-list";
@@ -1204,8 +1200,114 @@ _: {
                     name = "Ciara";
                     color = "#10b981";
                   }
+                  # Holland's calendar — entity arrives later.
+                  {
+                    entity = "calendar.holland";
+                    name = "Holland";
+                    color = "#a855f7";
+                  }
                 ];
                 grid_options.columns = "full";
+              }
+            ];
+          }
+        ];
+      };
+
+      # ── Finn dashboard (private; phone/sidebar, NOT on the shared kiosk) ──
+      # Holds the items split out of the shared home view: a pending-meds alert
+      # with quick "taken" toggles, the vacuum/humidifier consumable warning
+      # chips (now ChoreOps chores assigned to specific people), and Finn's
+      # chore to-do list. Single view; reachable from the HA sidebar.
+      finnView = {
+        type = "sections";
+        title = "Finn";
+        icon = "mdi:account";
+        path = "finn";
+        max_columns = 2;
+        badges = [
+          {
+            type = "entity";
+            show_state = true;
+            show_icon = true;
+            entity = "sensor.nougat_battery_level";
+            color = "state";
+          }
+        ];
+        sections = [
+          # ── Meds: alert (when pending) + mark-taken toggles ───────────────
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "Meds";
+                heading_style = "title";
+                icon = "mdi:pill";
+              }
+              medsCard
+              {
+                type = "grid";
+                columns = 2;
+                square = false;
+                cards = [
+                  {
+                    type = "tile";
+                    entity = "input_boolean.morning_meds_taken";
+                    name = "Morning";
+                    icon = "mdi:weather-sunny";
+                  }
+                  {
+                    type = "tile";
+                    entity = "input_boolean.night_meds_taken";
+                    name = "Night";
+                    icon = "mdi:weather-night";
+                  }
+                ];
+              }
+            ];
+          }
+          # ── To-do: Finn's chores + today's calendar ───────────────────────
+          {
+            type = "grid";
+            cards = [
+              {
+                type = "heading";
+                heading = "To-do";
+                heading_style = "title";
+                icon = "mdi:format-list-checks";
+              }
+              choresTodo
+              (calendarToday "calendar.finn" "#f97316")
+            ];
+          }
+          # ── Upkeep: vacuum / humidifier consumable warnings ───────────────
+          {
+            type = "grid";
+            column_span = 2;
+            cards = [
+              {
+                type = "heading";
+                heading = "Upkeep";
+                heading_style = "title";
+                icon = "mdi:wrench";
+              }
+              consumableChips
+              {
+                type = "custom:mushroom-chips-card";
+                alignment = "start";
+                chips = [
+                  {
+                    type = "template";
+                    icon = "mdi:robot-vacuum-variant";
+                    icon_color = "blue";
+                    content = "Cleaning";
+                    tap_action = {
+                      action = "navigate";
+                      navigation_path = "/nixos-home/cleaning";
+                    };
+                  }
+                ];
               }
             ];
           }
@@ -1220,6 +1322,11 @@ _: {
           lightsView
           weekView
         ];
+      };
+
+      finnDashboard = yamlFormat.generate "lovelace-finn.yaml" {
+        title = "Finn";
+        views = [ finnView ];
       };
     in
     {
@@ -1248,7 +1355,20 @@ _: {
         show_in_sidebar = true;
       };
 
-      # Reload on rebuild when the generated dashboard changes (no manual push).
-      systemd.services.home-assistant.reloadTriggers = [ homeDashboard ];
+      # Finn's private dashboard — sidebar only (the shared iPad kiosk points at
+      # /nixos-home/home and never shows the sidebar, so this stays off it).
+      services.home-assistant.config.lovelace.dashboards.nixos-finn = {
+        mode = "yaml";
+        filename = "${finnDashboard}";
+        title = "Finn";
+        icon = "mdi:account";
+        show_in_sidebar = true;
+      };
+
+      # Reload on rebuild when either generated dashboard changes (no manual push).
+      systemd.services.home-assistant.reloadTriggers = [
+        homeDashboard
+        finnDashboard
+      ];
     };
 }

--- a/modules/iot/homeassistant.nix
+++ b/modules/iot/homeassistant.nix
@@ -1025,6 +1025,78 @@
             ];
           }
 
+          # ── ChoreOps: litter chore — assign turn to lower-points person ──────
+          # "Take out Cat Poop Bag & Reline" rotates between Finn and Ciara via
+          # rotation_smart (which picks by this chore's own completion count).
+          # The household instead wants the next turn to go to whoever has
+          # fewer ChoreOps points overall, so this overrides the engine's pick
+          # whenever either person's point total changes (i.e. right after one
+          # of them gets a chore approved). Ties are left alone — rotation_smart's
+          # own pick stands.
+          {
+            alias = "ChoreOps: Litter chore — assign turn to lower-points person";
+            id = "choreops_litter_turn_by_points";
+            trigger = [
+              {
+                platform = "state";
+                entity_id = [
+                  "sensor.finn_choreops_points"
+                  "sensor.ciara_choreops_points"
+                ];
+              }
+              {
+                platform = "time_pattern";
+                minutes = "/30";
+              }
+            ];
+            condition = [
+              {
+                condition = "template";
+                value_template = "{{ states('sensor.finn_choreops_points') not in ['unavailable', 'unknown', ''] and states('sensor.ciara_choreops_points') not in ['unavailable', 'unknown', ''] }}";
+              }
+            ];
+            action = [
+              {
+                choose = [
+                  {
+                    conditions = [
+                      {
+                        condition = "template";
+                        value_template = "{{ states('sensor.finn_choreops_points') | float(0) < states('sensor.ciara_choreops_points') | float(0) }}";
+                      }
+                    ];
+                    sequence = [
+                      {
+                        service = "choreops.set_rotation_turn";
+                        data = {
+                          chore_name = "Take out Cat Poop Bag & Reline";
+                          user_name = "Finn";
+                        };
+                      }
+                    ];
+                  }
+                  {
+                    conditions = [
+                      {
+                        condition = "template";
+                        value_template = "{{ states('sensor.ciara_choreops_points') | float(0) < states('sensor.finn_choreops_points') | float(0) }}";
+                      }
+                    ];
+                    sequence = [
+                      {
+                        service = "choreops.set_rotation_turn";
+                        data = {
+                          chore_name = "Take out Cat Poop Bag & Reline";
+                          user_name = "Ciara";
+                        };
+                      }
+                    ];
+                  }
+                ];
+              }
+            ];
+          }
+
           # ── Phone: low-battery calendar reminder ───────────────────────────
           # Notifies 3 hours before a calendar event starts if battery is
           # below 30% and the phone is not already charging.

--- a/modules/iot/homeassistant.nix
+++ b/modules/iot/homeassistant.nix
@@ -84,7 +84,11 @@
       eufyWaterLevelSensor = "sensor.vaccum_water_level";
       eufyErrorSensor = "sensor.vaccum_error_message";
       levoitWaterSensor = "binary_sensor.humidifier_low_water";
-      todoistLabel = "care";
+
+      # Telemetry automations make the matching ChoreOps chore due via
+      # choreops.set_chore_due_date. The service rejects past dates, so nudge the
+      # timestamp 1 minute ahead — the chore shows as due/overdue immediately.
+      choreDueSoon = "{{ (now() + timedelta(minutes=1)).isoformat() }}";
 
       # ── YAML generation ─────────────────────────────────────────────────
       yamlFormat = pkgs.formats.yaml { };
@@ -196,10 +200,10 @@
         # Moved out of services.home-assistant.config so HA merges both Nix and UI
         # automations via `automation manual:` / `automation ui:` !include directives.
         iotHass.nixAutomations = [
-          # ── Eufy: low-water Todoist task ────────────────────────────────
-          # Uses a dedupe flag so repeated triggers do not spam Todoist.
+          # ── Eufy: low-water → make ChoreOps chore due ───────────────────
+          # Uses a dedupe flag so repeated triggers do not re-set the due date.
           {
-            alias = "Eufy: Low water — create Todoist task";
+            alias = "Eufy: Low water — make ChoreOps chore due";
             id = "eufy_low_water_task";
             trigger = [
               {
@@ -221,14 +225,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Refill Eufy vacuum water tank";
-                  description = "Refill tank to prevent cleaning interruptions. (Status: Low water warning)";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 2;
+                  chore_name = "Fill Vacuum Water Tank";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -240,10 +240,10 @@
             ];
           }
 
-          # ── Eufy: error + Todoist task ──────────────────────────────────
+          # ── Eufy: error → make ChoreOps chore due ───────────────────────
           # Fires for low-water error states; dedupe-guarded.
           {
-            alias = "Eufy: Error — create Todoist task";
+            alias = "Eufy: Error — make ChoreOps chore due";
             id = "eufy_error_task";
             trigger = [
               {
@@ -264,14 +264,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Refill Eufy vacuum water tank";
-                  description = "Refill tank and manually resume the vacuum. (Status: Paused with error)";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 2;
+                  chore_name = "Fill Vacuum Water Tank";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -284,7 +280,7 @@
           }
 
           # ── Eufy: water guard — create task if water critically low ─────
-          # Creates a Todoist task when water is below 15%.
+          # Makes the chore due when water is below 15%.
           {
             alias = "Eufy: Guard — create task if water critically low";
             id = "eufy_water_guard";
@@ -313,14 +309,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Refill Eufy vacuum water tank";
-                  description = "Refill tank before starting the next cycle. (Status: Water critically low)";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 2;
+                  chore_name = "Fill Vacuum Water Tank";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -358,16 +350,22 @@
                   entity_id = "input_boolean.eufy_water_task_open";
                 };
               }
+              {
+                # Resolved outside ChoreOps — clear the due date so the chore
+                # returns to dormant (no due_date ⇒ cleared).
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Fill Vacuum Water Tank";
+              }
             ];
           }
 
-          # ── Eufy: consumable wear-life → Todoist tasks ──────────────────
+          # ── Eufy: consumable wear-life → make ChoreOps chores due ───────
           # Mirrors the Eufy low-water pattern: each consumable has a
           # warning automation (fires at ~10% of lifespan) and a reset
           # automation (fires when the value jumps back above ~90% after
           # the user presses the corresponding reset button in HA).
           {
-            alias = "Eufy: Filter low — create Todoist task";
+            alias = "Eufy: Filter low — make ChoreOps chore due";
             id = "eufy_filter_low_task";
             trigger = [
               {
@@ -389,14 +387,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Replace Eufy vacuum HEPA filter";
-                  description = "Filter has {{ states('sensor.vaccum_filter_remaining') }}h life remaining (360h total). Press the Reset Filter button in HA after installing the new one.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Replace Vacuum HEPA Filter";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -432,11 +426,15 @@
                   entity_id = "input_boolean.vacuum_filter_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Replace Vacuum HEPA Filter";
+              }
             ];
           }
 
           {
-            alias = "Eufy: Rolling brush low — create Todoist task";
+            alias = "Eufy: Rolling brush low — make ChoreOps chore due";
             id = "eufy_rolling_brush_low_task";
             trigger = [
               {
@@ -458,14 +456,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Replace Eufy vacuum rolling brush";
-                  description = "Rolling brush has {{ states('sensor.vaccum_rolling_brush_remaining') }}h life remaining (360h total). Press the Reset Rolling Brush button in HA after installing the new one.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Replace Vacuum Rolling Brush";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -501,11 +495,15 @@
                   entity_id = "input_boolean.vacuum_rolling_brush_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Replace Vacuum Rolling Brush";
+              }
             ];
           }
 
           {
-            alias = "Eufy: Side brush low — create Todoist task";
+            alias = "Eufy: Side brush low — make ChoreOps chore due";
             id = "eufy_side_brush_low_task";
             trigger = [
               {
@@ -527,14 +525,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Replace Eufy vacuum side brush";
-                  description = "Side brush has {{ states('sensor.vaccum_side_brush_remaining') }}h life remaining (180h total). Press the Reset Side Brush button in HA after installing the new one.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Replace Vacuum Side Brush";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -570,11 +564,15 @@
                   entity_id = "input_boolean.vacuum_side_brush_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Replace Vacuum Side Brush";
+              }
             ];
           }
 
           {
-            alias = "Eufy: Nav sensors due for cleaning — create Todoist task";
+            alias = "Eufy: Nav sensors due for cleaning — make ChoreOps chore due";
             id = "eufy_sensors_low_task";
             trigger = [
               {
@@ -596,14 +594,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Clean Eufy vacuum nav sensors";
-                  description = "Wipe IR/cliff sensors with a dry microfibre cloth. {{ states('sensor.vaccum_sensor_remaining') }}h life remaining (60h total). Press the Reset Sensors button in HA when done.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Clean Vacuum Nav Sensors";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -639,11 +633,15 @@
                   entity_id = "input_boolean.vacuum_sensors_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Clean Vacuum Nav Sensors";
+              }
             ];
           }
 
           {
-            alias = "Eufy: Cleaning tray due for service — create Todoist task";
+            alias = "Eufy: Cleaning tray due for service — make ChoreOps chore due";
             id = "eufy_cleaning_tray_low_task";
             trigger = [
               {
@@ -665,14 +663,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Clean Eufy vacuum cleaning tray";
-                  description = "Rinse the mopping tray and clear any debris. {{ states('sensor.vaccum_cleaning_tray_remaining') }}h life remaining (30h total). Press the Reset Cleaning Tray button in HA when done.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Clean Vacuum Cleaning Tray";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -708,11 +702,15 @@
                   entity_id = "input_boolean.vacuum_cleaning_tray_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Clean Vacuum Cleaning Tray";
+              }
             ];
           }
 
           {
-            alias = "Eufy: Mop cloth low — create Todoist task";
+            alias = "Eufy: Mop cloth low — make ChoreOps chore due";
             id = "eufy_mopping_cloth_low_task";
             trigger = [
               {
@@ -734,14 +732,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Wash Eufy mopping cloth (or replace if worn)";
-                  description = "Mopping cloth has {{ states('sensor.vaccum_mopping_cloth_remaining') }}h life remaining (180h total). Press the Reset Mopping Cloth button in HA after replacing.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Wash Vacuum Mop Cloth";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -777,13 +771,17 @@
                   entity_id = "input_boolean.vacuum_mopping_cloth_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Wash Vacuum Mop Cloth";
+              }
             ];
           }
 
-          # ── Levoit: low-water Todoist task ──────────────────────────────
-          # Uses a dedupe flag so repeated triggers do not spam Todoist.
+          # ── Levoit: low-water → make ChoreOps chore due ─────────────────
+          # Uses a dedupe flag so repeated triggers do not re-set the due date.
           {
-            alias = "Levoit: Low water — create Todoist task";
+            alias = "Levoit: Low water — make ChoreOps chore due";
             id = "levoit_low_water_task";
             trigger = [
               {
@@ -801,14 +799,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Refill Levoit humidifier water tank";
-                  description = "Remember how nice it is to have nice air?";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Fill Humidifier";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -846,15 +840,19 @@
                   entity_id = "input_boolean.levoit_water_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Fill Humidifier";
+              }
             ];
           }
 
-          # ── Levoit: filter sponges → Todoist order task ─────────────────
+          # ── Levoit: filter sponges → make ChoreOps order chore due ──────
           # No reset button on the integration — sensor jumps back to ~100
           # automatically when a new filter is installed and the device
           # registers it.
           {
-            alias = "Levoit: Filter sponges low — create Todoist task";
+            alias = "Levoit: Filter sponges low — make ChoreOps chore due";
             id = "levoit_filter_low_task";
             trigger = [
               {
@@ -876,14 +874,10 @@
             ];
             action = [
               {
-                service = "todoist.new_task";
+                service = "choreops.set_chore_due_date";
                 data = {
-                  content = "Order new Levoit humidifier filter sponges";
-                  description = "Filter at {{ states('sensor.humidifier_filter_lifetime') }}% — Levoit replacement sponges typically last ~3 months.";
-                  project = "Chores";
-                  due_date_string = "today";
-                  labels = todoistLabel;
-                  priority = 3;
+                  chore_name = "Order Levoit Filter Sponges";
+                  due_date = choreDueSoon;
                 };
               }
               {
@@ -919,25 +913,43 @@
                   entity_id = "input_boolean.levoit_filter_task_open";
                 };
               }
+              {
+                service = "choreops.set_chore_due_date";
+                data.chore_name = "Order Levoit Filter Sponges";
+              }
             ];
           }
 
-          # ── Consumables: press hardware reset when Todoist task is completed ──
+          # ── Consumables: press hardware reset when ChoreOps chore completed ──
           # Water + Levoit-filter sensors recover on their own (real-time level
           # or device-side detection), so they are not synced here. The Eufy
           # consumables below only reset when the corresponding HA button is
-          # pressed; doing it here lets checking the Todoist task off also
-          # reset the on-device wear-life counter. The existing
-          # `*_renewed_reset` automations then clear the dedupe flag once the
-          # sensor jumps back to ~100%.
+          # pressed; doing it here lets completing the ChoreOps chore also reset
+          # the on-device wear-life counter. The existing `*_renewed_reset`
+          # automations then clear the dedupe flag (and the chore's due date)
+          # once the sensor jumps back to ~100%.
+          #
+          # ChoreOps fires no events, so we watch each chore's status sensor.
+          # Finn-only ("independent") chores expose only a per-assignee sensor
+          # (sensor.finn_choreops_chore_status_<slug>); shared chores expose a
+          # global-status sensor (sensor.office_system_choreops_<slug>_global_status).
+          # The time_pattern trigger re-checks periodically in case a status
+          # transition is missed.
           {
-            alias = "Consumables: Sync flags from Todoist completion";
-            id = "consumable_flag_sync_from_todoist";
+            alias = "Consumables: Press hardware reset when ChoreOps chore completed";
+            id = "consumable_reset_from_choreops";
             mode = "single";
             trigger = [
               {
                 platform = "state";
-                entity_id = "todo.chores";
+                entity_id = [
+                  "sensor.finn_choreops_chore_status_replace_vacuum_hepa_filter"
+                  "sensor.finn_choreops_chore_status_replace_vacuum_rolling_brush"
+                  "sensor.finn_choreops_chore_status_replace_vacuum_side_brush"
+                  "sensor.office_system_choreops_clean_vacuum_nav_sensors_global_status"
+                  "sensor.office_system_choreops_clean_vacuum_cleaning_tray_global_status"
+                  "sensor.office_system_choreops_wash_vacuum_mop_cloth_global_status"
+                ];
               }
               {
                 platform = "time_pattern";
@@ -946,46 +958,36 @@
             ];
             action = [
               {
-                service = "todo.get_items";
-                target = {
-                  entity_id = "todo.chores";
-                };
-                data = {
-                  status = "needs_action";
-                };
-                response_variable = "chores";
-              }
-              {
                 repeat = {
                   for_each = [
                     {
                       flag = "vacuum_filter_task_open";
-                      summary = "Replace Eufy vacuum HEPA filter";
+                      status_sensor = "sensor.finn_choreops_chore_status_replace_vacuum_hepa_filter";
                       reset_button = "button.vaccum_reset_filter";
                     }
                     {
                       flag = "vacuum_rolling_brush_task_open";
-                      summary = "Replace Eufy vacuum rolling brush";
+                      status_sensor = "sensor.finn_choreops_chore_status_replace_vacuum_rolling_brush";
                       reset_button = "button.vaccum_reset_rolling_brush";
                     }
                     {
                       flag = "vacuum_side_brush_task_open";
-                      summary = "Replace Eufy vacuum side brush";
+                      status_sensor = "sensor.finn_choreops_chore_status_replace_vacuum_side_brush";
                       reset_button = "button.vaccum_reset_side_brush";
                     }
                     {
                       flag = "vacuum_sensors_task_open";
-                      summary = "Clean Eufy vacuum nav sensors";
+                      status_sensor = "sensor.office_system_choreops_clean_vacuum_nav_sensors_global_status";
                       reset_button = "button.vaccum_reset_sensors";
                     }
                     {
                       flag = "vacuum_cleaning_tray_task_open";
-                      summary = "Clean Eufy vacuum cleaning tray";
+                      status_sensor = "sensor.office_system_choreops_clean_vacuum_cleaning_tray_global_status";
                       reset_button = "button.vaccum_reset_cleaning_tray";
                     }
                     {
                       flag = "vacuum_mopping_cloth_task_open";
-                      summary = "Wash Eufy mopping cloth (or replace if worn)";
+                      status_sensor = "sensor.office_system_choreops_wash_vacuum_mop_cloth_global_status";
                       reset_button = "button.vaccum_reset_mopping_cloth";
                     }
                   ];
@@ -997,9 +999,8 @@
                             {
                               condition = "template";
                               value_template = ''
-                                {% set items = (chores | default({})).get('todo.chores', {}).get('items', []) %}
-                                {% set summaries = items | map(attribute='summary') | list %}
-                                {{ is_state('input_boolean.' ~ repeat.item.flag, 'on') and repeat.item.summary not in summaries }}
+                                {{ is_state('input_boolean.' ~ repeat.item.flag, 'on')
+                                   and states(repeat.item.status_sensor) in ['approved', 'completed'] }}
                               '';
                             }
                           ];
@@ -2372,12 +2373,12 @@
             # ── Eufy vacuum helpers ──────────────────────────────────────────
             input_boolean = {
               eufy_water_task_open = {
-                name = "Eufy water Todoist task open";
+                name = "Eufy water chore due";
                 icon = "mdi:water-alert";
                 initial = "off";
               };
               levoit_water_task_open = {
-                name = "Levoit humidifier water Todoist task open";
+                name = "Levoit humidifier water chore due";
                 icon = "mdi:water-alert";
                 initial = "off";
               };
@@ -2409,37 +2410,37 @@
                 initial = "off";
               };
               vacuum_filter_task_open = {
-                name = "Vacuum filter Todoist task open";
+                name = "Vacuum filter chore due";
                 icon = "mdi:air-filter";
                 initial = "off";
               };
               vacuum_rolling_brush_task_open = {
-                name = "Vacuum rolling brush Todoist task open";
+                name = "Vacuum rolling brush chore due";
                 icon = "mdi:broom";
                 initial = "off";
               };
               vacuum_side_brush_task_open = {
-                name = "Vacuum side brush Todoist task open";
+                name = "Vacuum side brush chore due";
                 icon = "mdi:broom";
                 initial = "off";
               };
               vacuum_sensors_task_open = {
-                name = "Vacuum sensor cleaning Todoist task open";
+                name = "Vacuum sensor cleaning chore due";
                 icon = "mdi:eye-check";
                 initial = "off";
               };
               vacuum_cleaning_tray_task_open = {
-                name = "Vacuum cleaning tray Todoist task open";
+                name = "Vacuum cleaning tray chore due";
                 icon = "mdi:tray-alert";
                 initial = "off";
               };
               vacuum_mopping_cloth_task_open = {
-                name = "Vacuum mopping cloth Todoist task open";
+                name = "Vacuum mopping cloth chore due";
                 icon = "mdi:dishwasher";
                 initial = "off";
               };
               levoit_filter_task_open = {
-                name = "Levoit filter sponges Todoist task open";
+                name = "Levoit filter sponges chore due";
                 icon = "mdi:air-filter";
                 initial = "off";
               };

--- a/modules/iot/homeassistant.nix
+++ b/modules/iot/homeassistant.nix
@@ -930,11 +930,14 @@
           # once the sensor jumps back to ~100%.
           #
           # ChoreOps fires no events, so we watch each chore's status sensor.
-          # Finn-only ("independent") chores expose only a per-assignee sensor
-          # (sensor.finn_choreops_chore_status_<slug>); shared chores expose a
-          # global-status sensor (sensor.office_system_choreops_<slug>_global_status).
-          # The time_pattern trigger re-checks periodically in case a status
-          # transition is missed.
+          # Cleaning chores ("shared_first") expose a global-status sensor
+          # (sensor.office_system_choreops_<slug>_global_status) whose STATE is the
+          # overall state. Part-swap chores ("rotation_primary_standby") expose no
+          # global-status sensor — we watch Finn's per-assignee sensor
+          # (sensor.finn_choreops_chore_status_<slug>) and read its `global_state`
+          # ATTRIBUTE, which reflects completion by Finn OR a standby roommate. The
+          # condition below checks both forms. The time_pattern trigger re-checks
+          # periodically in case a status (or attribute-only) transition is missed.
           {
             alias = "Consumables: Press hardware reset when ChoreOps chore completed";
             id = "consumable_reset_from_choreops";
@@ -1000,7 +1003,8 @@
                               condition = "template";
                               value_template = ''
                                 {{ is_state('input_boolean.' ~ repeat.item.flag, 'on')
-                                   and states(repeat.item.status_sensor) in ['approved', 'completed'] }}
+                                   and (states(repeat.item.status_sensor) in ['approved', 'completed']
+                                        or state_attr(repeat.item.status_sensor, 'global_state') in ['approved', 'completed']) }}
                               '';
                             }
                           ];
@@ -1448,8 +1452,32 @@
                     ];
                   }
                 ];
-                # ── Daytime (6am → sunset): only set fairy lights preset ─────────
+                # ── Daytime (6am → sunset): bright warm lights on arrival ────────
+                # Room lights still come on so arrivals before sunset aren't
+                # left dark (summer evenings, overcast days). Brighter + neutral
+                # warm white rather than the dim red used after dark.
                 default = [
+                  {
+                    service = "light.turn_on";
+                    target = {
+                      entity_id = "light.living_room";
+                    };
+                    data = {
+                      color_temp_kelvin = 2700;
+                      brightness_pct = 70;
+                      transition = 3;
+                    };
+                  }
+                  {
+                    service = "light.turn_on";
+                    target = {
+                      entity_id = "light.smart_led_bulb_2";
+                    };
+                    data = {
+                      brightness_pct = 60;
+                      transition = 3;
+                    };
+                  }
                   {
                     choose = [
                       {

--- a/modules/iot/roomieorder.nix
+++ b/modules/iot/roomieorder.nix
@@ -31,13 +31,13 @@ in
       yamlFormat = pkgs.formats.yaml { };
 
       # The dynamic grid uses custom:mushroom-template-card (gray-out + "N ago"),
-      # so the mushroom frontend must be loaded. Shipping it as a customLovelace
-      # module makes the HA module (a) serve it at
-      # /local/nixos-lovelace-modules/mushroom.js, (b) auto-set
-      # lovelace.resource_mode = "yaml", and (c) emit the lovelace.resources entry
-      # (via homeassistant.nix's customLovelaceModules → resources merge) — which
-      # is what loads the JS even though the DEFAULT dashboard stays storage mode.
-      mushroom = pkgs.home-assistant-custom-lovelace-modules.mushroom;
+      # so the mushroom frontend must be loaded. mushroom (and every other custom
+      # module on iot) is declared once in dashboard-home.nix's
+      # customLovelaceModules list — the single source of truth for frontend
+      # resources — so we do NOT re-declare it here (that would emit a duplicate
+      # lovelace.resources entry). The HA module serves it at
+      # /local/nixos-lovelace-modules/mushroom.js and auto-sets
+      # lovelace.resource_mode = "yaml", which loads the JS for this dashboard too.
 
       # One YAML-mode dashboard, one view, the catalog-derived dynamic grid.
       # yamlFormat.generate's out path IS the .yaml file, so we can point HA's
@@ -51,14 +51,31 @@ in
             title = "Reorder";
             path = "reorder";
             icon = "mdi:cart";
-            cards = [ buttons.dashboardCardDynamic ];
+            cards = [
+              # Back to the kiosk home view (the kiosk has no sidebar). The
+              # nixos-home dashboard's Reorder chip navigates here.
+              {
+                type = "custom:mushroom-chips-card";
+                alignment = "start";
+                chips = [
+                  {
+                    type = "template";
+                    icon = "mdi:arrow-left";
+                    content = "Back";
+                    tap_action = {
+                      action = "navigate";
+                      navigation_path = "/nixos-home/home?kiosk";
+                    };
+                  }
+                ];
+              }
+              buttons.dashboardCardDynamic
+            ];
           }
         ];
       };
     in
     {
-      services.home-assistant.customLovelaceModules = [ mushroom ];
-
       services.home-assistant.config = {
         rest_command = buttons.restCommand;
         # Per-item status sensors (one GET /items poll, one sensor per item) that

--- a/modules/iot/vnc-ipad.nix
+++ b/modules/iot/vnc-ipad.nix
@@ -5,7 +5,9 @@ _: {
       ports = [ "5900:5900" ]; # LAN only — iot is not WAN-exposed
       environment = {
         VNC_PASSWORD = "ipad";
-        STARTING_WEBSITE_URL = "http://192.168.8.111:8123/main-home/0?kiosk";
+        # Declarative kiosk (modules/iot/dashboard-home.nix). Replaces the old
+        # storage-mode main-home dashboard, which stays as a manual fallback.
+        STARTING_WEBSITE_URL = "http://192.168.8.111:8123/nixos-home/home?kiosk";
         VNC_RESOLUTION = "1536x1152"; # 4:3, midpoint between 1024x768 and iPad Air native 2048x1536
       };
       volumes = [

--- a/modules/link/gamestream.nix
+++ b/modules/link/gamestream.nix
@@ -37,6 +37,15 @@
       #   pkgs.runCommand "${lib.nameFromURL url "."}.png" {} ''${pkgs.imagemagick}/bin/convert ${image} -background none -gravity center -extent 600x800 $out'';
       # implementation from https://github.com/TophC7/dot.nix/blob/724e87bb986f4e722490b0b739b8cbf57f1d5fcc/home/global/common/gaming/gamescope.nix
       gamescope-env = ''
+        # MangoHud's session-wide env vars (modules/gaming/mangohud.nix) hook
+        # every Vulkan process, including gamescope's own internal compositor
+        # device. That double-hook crashes gamescope at shutdown (SIGSEGV in
+        # libMangoHud.so during gamescope's CVulkanDevice teardown). gamescope
+        # ships its own --mangoapp overlay specifically to avoid this; unset
+        # the global hook here and rely on --mangoapp (added in
+        # gamescope-base-opts below) instead.
+        set -e MANGOHUD
+        set -e MANGOHUD_DLSYM
         set -x ENABLE_GAMESCOPE_WSI 1
         set -x ENABLE_HDR_WSI 1
         set -x DXVK_HDR 1
@@ -73,6 +82,7 @@
         "--force-grab-cursor"
         "--hide-cursor-delay"
         "3000"
+        "--mangoapp"
       ];
       # exec ${config.security.wrappers.gamescope.program} $final_args -- $argv
       gamescope-run = pkgs.writers.writeFishBin "gamescope-run" ''

--- a/modules/link/roomieorder.nix
+++ b/modules/link/roomieorder.nix
@@ -99,6 +99,15 @@ in
         };
       };
 
+      # Publish the unit's non-secret env (baseEnv) as a dotenv file so the
+      # roomieorder dev shell / a terminal `roomieorder` can mirror exactly what
+      # the service runs with — same catalog, Chrome, caps, host/port and state
+      # paths — instead of re-deriving them. The repo's .envrc dotenvs this plus
+      # /run/agenix/roomieorder (the secrets). Single source: the module's
+      # baseEnv. Holds no secrets, so /etc exposure matches the unit's
+      # world-readable Environment=.
+      environment.etc."roomieorder/env".source = config.services.roomieorder.envFile;
+
       # Intake port for HA on iot. The LAN is trusted (every other link service
       # opens its port the same way); to scope it to iot only, switch to an
       # nftables `extraInputRules` rule keyed on ${iotLanIp}.


### PR DESCRIPTION
- **feat: declarative nixos-home kiosk dashboard**
- **feat: much nicer hass dashboarod**
- **feat: choreops ha skill**
- **fix: split chores & redesign dashboard**
- **fix: turn on lights when we get home**
- **fix: horizontal layout on person card**
- **fix: greeting as chip and not card**
- **fix: hide apple tv card**
- **feat: only show chores that need to be done**
- **fix: chips go gray if can be done by anyone**
- **fix: rotate kitty litter by less points**
- **fix: use gamescopes own --mangoapp overlay**
- **fix: add baseEnv roomieorder feature**
- **feat: correct notes about what is live**
