### PR TITLE
fix(ci): exclude packages with transitive aarch64-incompatible deps from checks

### DIFF
--- a/modules/package-checks.nix
+++ b/modules/package-checks.nix
@@ -5,10 +5,19 @@
     {
       # Only expose a package as a check on systems where it can actually be
       # built. This keeps the aarch64 check set to the portable subset and
-      # avoids surfacing packages that are explicitly x86_64-only.
+      # avoids surfacing packages that are explicitly x86_64-only. The
+      # tryEval also catches packages whose own meta.platforms is
+      # unrestricted but that pull in a transitively platform-restricted
+      # dependency (e.g. beets-plugins -> essentia-extractor, x86_64/i686
+      # only) — forcing drvPath is what trips nixpkgs' checkMeta assertion
+      # in that case, not the top-level availableOn check.
       checks =
         self'.packages
-        |> lib.filterAttrs (_: drv: lib.meta.availableOn pkgs.stdenv.hostPlatform drv)
+        |> lib.filterAttrs (
+          _: drv:
+          lib.meta.availableOn pkgs.stdenv.hostPlatform drv
+          && (builtins.tryEval drv.drvPath).success
+        )
         |> lib.mapAttrs' (name: drv: lib.nameValuePair "packages/${name}" drv);
     };
 }


### PR DESCRIPTION
beets-plugins pulls in essentia-extractor, which only supports x86_64/i686.
Its own meta.platforms doesn't reflect that, so the existing availableOn
filter let it through and CI hard-failed forcing its drvPath every run on
aarch64. Extend the filter to drop any package whose drvPath fails to
evaluate, not just ones with their own restrictive meta.platforms.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RS3oTNuNsZzmHGqqoY8Vdf