### PR TITLE
Add anki and anki-connect skills with a Nix-packaged anki-tools CLI

### DIFF
--- a/docs/skills/anki-connect/SKILL.md
+++ b/docs/skills/anki-connect/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: anki-connect
+description: Push high-quality flashcards (Basic and Cloze) directly into an already-running Anki via the AnkiConnect add-on (HTTP localhost:8765) — live insertion, no file to import. Use when the user wants cards added straight into Anki now, or wants to browse/find/update notes in a running Anki. To produce a portable .apkg file instead, use the anki skill.
+tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+# Anki-Connect: push cards into a running Anki
+
+Insert cards live into a running Anki using the AnkiConnect add-on, instead of
+producing a `.apkg`. Cards use the **same `cards.json` schema** and the **same
+card-writing methodology** as the `anki` skill — the only difference is the
+backend.
+
+## Prerequisite check (always first)
+
+AnkiConnect requires Anki **desktop to be running** with the AnkiConnect add-on
+installed (this repo installs it via `modules/productivity/anki.nix`). Probe it:
+
+```
+anki-connect version
+```
+
+If that errors (connection refused), tell the user to open Anki, and offer the
+`anki` skill (`.apkg` export) as the offline alternative. Do not proceed until
+the probe succeeds.
+
+## Workflow
+
+1. **Probe** with `anki-connect version`.
+2. **Draft `cards.json`** following the methodology below. Schema:
+   `../anki/reference/json-schema.md`. Full rulebook:
+   `../anki/reference/card-writing.md` — **load it before drafting.**
+3. **Self-review** every card against the checklist in `card-writing.md`.
+4. **Show the drafted cards to the user for approval/edits** before inserting —
+   live insertion writes directly into their collection.
+5. **Insert:** `anki-add-notes cards.json`
+   - creates the deck if needed, runs `canAddNotes` to skip duplicates, then
+     `addNotes`. Add `--allow-duplicate` to force, `--dry-run` to preview the
+     payload without touching Anki.
+6. **Report** how many were added vs skipped.
+
+## Methodology and card-type choice
+
+Identical to the `anki` skill — do not re-derive it here. In brief:
+
+- **Minimum information principle**: one atom per card; unambiguous cue → single
+  answer; no dumps, lists, or enumerations; short both sides; stands alone.
+- **Cloze** for facts-in-context (default for declarative facts); **Basic** for
+  genuine Q→A; **Basic+Reversed** only when both directions are unambiguous.
+- Cloze: 1–3 deletions, no giveaways (use `{{c1::answer::hint}}`), correct
+  c-number grouping (same number = one card, different = separate cards).
+
+The authoritative details, cloze deep-dive, bad→good gallery, and review
+checklist are in **`../anki/reference/card-writing.md`**.
+
+## Note-type mapping (to Anki's built-in models)
+
+- `basic` → **Basic**
+- `reversed` → **Basic (and reversed card)**
+- `cloze` → **Cloze**
+
+Anki's built-in *Basic* model has no Extra field, so `anki-add-notes` appends a
+note's `extra` to the Back; cloze `extra` uses the native "Back Extra" field.
+
+## Ad-hoc AnkiConnect calls
+
+`anki-connect <action> '<json-params>'` runs any AnkiConnect action and prints
+the JSON result — useful for browsing, searching, and editing:
+
+```
+anki-connect deckNames
+anki-connect findNotes '{"query": "deck:Spanish tag:exam1"}'
+anki-connect guiBrowse '{"query": "added:1"}'
+```
+
+See `reference/ankiconnect-api.md` for the actions and request shapes.
+
+## The tool
+
+`anki-tools` (this repo's Nix package, `pkgs/anki-tools/`) provides
+`anki-add-notes` and `anki-connect`. Run via `nix run .#anki-tools` /
+`nix shell .#anki-tools`, or directly once on PATH after `home-manager switch`.
+No extra dependencies — the AnkiConnect path is pure stdlib.

--- a/docs/skills/anki-connect/reference/ankiconnect-api.md
+++ b/docs/skills/anki-connect/reference/ankiconnect-api.md
@@ -1,0 +1,115 @@
+# AnkiConnect API reference
+
+AnkiConnect exposes Anki over HTTP at `http://127.0.0.1:8765` while Anki desktop
+is running. Every request is an HTTP POST with a JSON body:
+
+```json
+{ "action": "<name>", "version": 6, "params": { } }
+```
+
+and every response has the shape:
+
+```json
+{ "result": <value>, "error": null }
+```
+
+`error` is `null` on success or a string message on failure. The `anki-connect`
+command wraps all of this — `anki-connect <action> '<json-params>'` — but the raw
+actions are documented here for when you need one the helper scripts don't cover.
+
+## Connection
+
+| Action | Params | Result |
+|--------|--------|--------|
+| `version` | — | the API version (e.g. `6`). Use as a health check. |
+| `sync` | — | triggers AnkiWeb sync. |
+
+```bash
+anki-connect version
+# or raw:
+curl -s localhost:8765 -X POST -d '{"action":"version","version":6}'
+```
+
+## Decks
+
+| Action | Params | Result |
+|--------|--------|--------|
+| `deckNames` | — | list of deck names |
+| `deckNamesAndIds` | — | `{name: id}` |
+| `createDeck` | `{"deck": "A::B"}` | new deck id (no-op if it exists) |
+| `changeDeck` | `{"cards": [id…], "deck": "X"}` | moves cards |
+| `deleteDecks` | `{"decks": ["X"], "cardsToo": true}` | — |
+
+## Note types (models)
+
+| Action | Params | Result |
+|--------|--------|--------|
+| `modelNames` | — | list of note-type names |
+| `modelFieldNames` | `{"modelName": "Basic"}` | field names for that model |
+
+Built-in models used by `anki-add-notes`: `Basic` (Front, Back),
+`Basic (and reversed card)` (Front, Back), `Cloze` (Text, Back Extra).
+
+## Notes
+
+| Action | Params | Result |
+|--------|--------|--------|
+| `addNote` | `{"note": <note>}` | new note id |
+| `addNotes` | `{"notes": [<note>…]}` | list of ids (`null` per failed note) |
+| `canAddNotes` | `{"notes": [<note>…]}` | list of booleans (false = duplicate/invalid) |
+| `findNotes` | `{"query": "deck:X tag:y"}` | list of note ids |
+| `notesInfo` | `{"notes": [id…]}` | fields, tags, model per note |
+| `updateNoteFields` | `{"note": {"id": id, "fields": {…}}}` | — |
+| `deleteNotes` | `{"notes": [id…]}` | — |
+| `addTags` / `removeTags` | `{"notes": [id…], "tags": "a b"}` | — |
+
+A **note** object:
+
+```json
+{
+  "deckName": "Biology::Cell",
+  "modelName": "Basic",
+  "fields": { "Front": "…", "Back": "…" },
+  "tags": ["bio", "exam1"],
+  "options": { "allowDuplicate": false }
+}
+```
+
+Example: add one note via the raw API —
+
+```bash
+curl -s localhost:8765 -X POST -d '{
+  "action": "addNote", "version": 6,
+  "params": { "note": {
+    "deckName": "Spanish", "modelName": "Basic",
+    "fields": {"Front": "perro", "Back": "dog"},
+    "tags": ["vocab"], "options": {"allowDuplicate": false}
+  }}
+}'
+```
+
+## Media
+
+| Action | Params | Result |
+|--------|--------|--------|
+| `storeMediaFile` | `{"filename": "x.png", "path": "/abs/x.png"}` or `{"filename","data": "<base64>"}` or `{"filename","url"}` | stored filename |
+| `retrieveMediaFile` | `{"filename": "x.png"}` | base64 contents |
+| `deleteMediaFile` | `{"filename": "x.png"}` | — |
+
+Reference stored media in fields with `<img src="x.png">` or `[sound:x.mp3]`.
+
+## GUI
+
+| Action | Params | Result |
+|--------|--------|--------|
+| `guiBrowse` | `{"query": "deck:X"}` | opens the Browse window, returns matching card ids |
+| `guiDeckOverview` | `{"name": "X"}` | opens a deck's overview |
+
+## Error & duplicate handling
+
+- A `null` entry in an `addNotes` result means that note failed (usually a
+  duplicate). `anki-add-notes` pre-filters with `canAddNotes` and reports skips.
+- To deliberately allow duplicates, set `options.allowDuplicate = true`
+  (`anki-add-notes --allow-duplicate`).
+- Anki search syntax (for `findNotes`/`guiBrowse`): `deck:Name`, `tag:x`,
+  `"front:exact"`, `added:1`, `is:due`, combinable with spaces (AND) and `or`.

--- a/docs/skills/anki/SKILL.md
+++ b/docs/skills/anki/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: anki
+description: Create high-quality Anki flashcards (Basic flip cards and Cloze deletions) following evidence-based card-writing principles, and export a ready-to-import .apkg. Use whenever the user wants to make, generate, write, review, or edit Anki cards/decks/flashcards from notes, text, PDFs, or study material. For pushing cards into an already-running Anki instead of producing a file, use the anki-connect skill.
+tools: Bash, Read, Write, Edit, Grep, Glob
+---
+
+# Anki: build .apkg decks
+
+Turn study material into well-formed Anki cards and export a portable `.apkg`.
+Cards are authored as a `cards.json` file and built with the Nix-packaged
+`anki-build-deck` command.
+
+## Workflow
+
+1. **Gather & confirm.** Identify the source material and the deck name (use
+   `::` for sub-decks, e.g. `Spanish::Verbs`). Ask only if genuinely unclear.
+2. **Draft `cards.json`.** Write the cards following the methodology below. Read
+   `reference/json-schema.md` for the exact format and `reference/card-writing.md`
+   for the full rulebook.
+3. **Self-review every card** against the checklist at the end of
+   `reference/card-writing.md` — atomic, unambiguous, right card type, no
+   lists/dumps. Fix before building.
+4. **Build:** `nix run .#anki-tools -- cards.json out.apkg`
+   (or `anki-build-deck cards.json out.apkg` once installed via home-manager;
+   omit the output path to default to `<deck-name>.apkg`).
+5. **Report** the card count and output path; offer to refine.
+
+## The methodology (this is the point — make cards *well*)
+
+Foundation: the **minimum information principle** — break material into the
+smallest meaningful pieces and test one per card. Non-negotiables:
+
+- **One atom per card** — a single fact, answerable in well under ~10 seconds.
+- **Unambiguous cue → single answer.** If two answers are defensible, the cue is
+  too vague; add context or split.
+- **No verbatim dumps; no naked lists / sets / enumerations.** Reformulate.
+- **Context-free but context-aware** — stands alone months later, yet carries
+  enough lead-in (or a topic tag) to be unambiguous.
+- **Keep both sides short.** A long answer is really several cards.
+
+The full 20-rule rationale, a bad→good gallery, and the review checklist live in
+`reference/card-writing.md`. **Load it before drafting.**
+
+## Basic vs Cloze vs Basic+Reversed — choose deliberately
+
+- **Cloze** when the fact is most natural *inside a sentence* and you're testing a
+  specific term/number/name/date in situ, or a definition where the sentence is
+  the cue. This is the default for declarative facts-in-context.
+  `The capital of Australia is {{c1::Canberra}}.`
+- **Basic** when there's a genuine question→answer with no useful sentence
+  context, or a term→definition you only need in one direction.
+- **Basic+Reversed** only when the association must be recalled **both**
+  directions AND both are individually unambiguous (vocab↔meaning, symbol↔name).
+  Never reverse one-to-many facts.
+
+**Refuse/rewrite cloze anti-patterns:** over-clozing (keep 1–3 deletions);
+grammatical/length giveaways (reword or add `{{c1::answer::hint}}`); unrelated
+facts crammed into one card; clozing the only meaningful word.
+
+Cloze c-numbers control cards: **same number reveals together on one card**,
+**different numbers make separate cards**. Use overlapping clozes (different
+numbers on one sentence) to replace enumerations. See the cloze deep-dive in
+`reference/card-writing.md`.
+
+## Round-trip editing of an existing deck
+
+`anki-parse-deck deck.apkg > cards.json` → edit the JSON → rebuild with
+`anki-build-deck`. Stable GUIDs mean re-importing the rebuilt deck updates the
+same notes rather than duplicating them.
+
+## Media
+
+Reference images/audio by basename in the card HTML and list the files under the
+note's `media` (paths relative to `cards.json`):
+`{"type":"basic","front":"<img src=\"diagram.png\">","back":"…","media":["diagram.png"]}`.
+
+## The tool
+
+`anki-tools` (this repo's Nix package, `pkgs/anki-tools/`) provides:
+`anki-build-deck` (cards.json → .apkg) and `anki-parse-deck` (.apkg → cards.json).
+Run via `nix run .#anki-tools -- …`, `nix shell .#anki-tools`, or directly once
+on PATH after `home-manager switch`.

--- a/docs/skills/anki/reference/card-writing.md
+++ b/docs/skills/anki/reference/card-writing.md
@@ -1,0 +1,183 @@
+# Card-writing rulebook (canonical)
+
+This is the single source of truth for *how* to write cards, shared by the
+`anki` and `anki-connect` skills. Read it before drafting cards and run the
+**self-review checklist** at the end before building/adding anything.
+
+The foundation is the **minimum information principle**: the material you learn
+should be broken into the smallest meaningful pieces, and each card should test
+exactly one of them. Almost every rule below is a consequence of this idea.
+
+---
+
+## The 20 rules of formulating knowledge (condensed)
+
+Adapted from Piotr Woźniak's *Twenty Rules of Formulating Knowledge*. Each is one
+line; the ones that change card *structure* are expanded later.
+
+1. **Understand before you memorize.** Never make cards from material you don't
+   yet understand — disconnected facts are nearly impossible to retain.
+2. **Learn before you memorize.** Build the big picture first; cards reinforce an
+   existing scaffold, they don't build it.
+3. **Build on the basics.** Don't skip "obvious" foundational cards; simple,
+   well-understood items are the cheap glue that holds advanced knowledge.
+4. **Minimum information principle.** Make items as simple as possible (but no
+   simpler). Simple items are easy to schedule and recall reliably.
+5. **Cloze deletion is easy and effective.** Fill-in-the-blank on a sentence is
+   one of the highest-yield, lowest-effort formats — prefer it for facts in context.
+6. **Use imagery.** A picture is worth a thousand words; add an image when it
+   carries the meaning faster than text.
+7. **Use mnemonic techniques** for arbitrary or interference-prone material.
+8. **Graphic deletion** (image occlusion) is to images what cloze is to text.
+9. **Avoid sets.** "Name all members of X" is brutal to recall; convert to
+   meaningful, individually-cued facts.
+10. **Avoid enumerations.** Ordered lists are nearly as bad as sets; use overlapping
+    cloze or relationships instead of "list the steps".
+11. **Combat interference.** Make similar-but-different items unmistakably distinct;
+    ambiguity between cards is the #1 cause of lapses.
+12. **Optimize wording.** Trim every word that isn't doing work; the cue should
+    snap to a single answer.
+13. **Refer to other memories** to anchor new items to ones you already hold.
+14. **Personalize and use examples** — your own examples are far stickier.
+15. **Rely on emotional states** when useful; vivid/affective cues recall better.
+16. **Context cues simplify wording** — a topic tag or short lead-in beats a long,
+    over-qualified question.
+17. **Redundancy is not bad** in knowledge (as opposed to data); multiple angles on
+    one fact strengthen it — but each angle is its *own* atomic card.
+18. **Provide sources** so a card can be re-verified months later.
+19. **Provide date stamping** for knowledge that changes over time.
+20. **Prioritize.** Make cards for what matters; cutting low-value cards is itself a skill.
+
+---
+
+## The non-negotiables (apply to every card)
+
+- **One atom per card.** A card tests a single fact answerable in well under ~10
+  seconds. Two independent facts → two cards.
+- **Unambiguous cue, single answer.** The front must admit exactly one correct
+  response. If you can think of two defensible answers, the cue is too vague —
+  add context or split it.
+- **No verbatim dumps.** Never paste a paragraph onto one side. Reformulate into a
+  precise question or a focused cloze.
+- **No naked lists / sets / enumerations.** Don't make "list the 5 X" cards (see
+  the worked example below).
+- **Context-free but context-aware.** The card must stand alone months later — no
+  "as mentioned above", no reference to the source document — yet carry enough
+  lead-in (or a topic tag) to make the cue unambiguous.
+- **Keep both sides short.** Long answers can't be graded honestly. If the answer
+  is long, it's really several cards.
+
+---
+
+## Basic vs Cloze vs Basic+Reversed — the decision
+
+Choose the type deliberately; the wrong type is the most common quality failure.
+
+### Use **Cloze** when…
+- The fact is most natural *inside a sentence / context*, and you want to test a
+  specific term, number, name, or date *in situ*.
+  - `The capital of Australia is {{c1::Canberra}}.`
+- A **definition** where the surrounding sentence is the cue.
+- You have **several related blanks** from one sentence that genuinely belong
+  together (use `c1`, `c2`, … — see grouping below).
+- Default to cloze for declarative facts-in-context; it's fast to write and study.
+
+### Use **Basic** when…
+- There's a genuine **question → answer** with no useful sentence context.
+  - Front: `What enzyme unwinds DNA at the replication fork?` → Back: `Helicase`
+- A **term ↔ definition** where you want clean recall in **one** direction only.
+- Anything that reads awkwardly as a fill-in-the-blank, or where the blank would
+  leave a giveaway.
+- The answer needs explanation/working that doesn't fit a single deletion.
+
+### Use **Basic + Reversed** when…
+- The association must be recalled in **both** directions **and** both directions
+  are individually unambiguous: vocabulary ↔ meaning, symbol ↔ name, term ↔
+  one-line definition.
+  - `perro` ↔ `dog` — fine to reverse.
+- **Do not reverse one-to-many facts.** `dog → perro` is fine, but
+  `mammal → dog` is not (many answers). If the reverse direction is ambiguous,
+  use plain Basic.
+
+### Cloze anti-patterns — refuse / rewrite these
+- **Over-clozing**: so many deletions the sentence is unreadable or the remaining
+  text gives no cue. Keep to **1–3 deletions** per card.
+- **Giveaways**: grammatical agreement or blank length that betrays the answer
+  (`an {{c1::}}…` hints a vowel; size of the blank hints word length). Reword, or
+  add a hint to normalize: `{{c1::Canberra::city}}`.
+- **Unrelated facts in one card**: clozing two facts that aren't really connected
+  just to save a card. Split them.
+- **Clozing the only meaningful word**, leaving a contentless stub
+  (`{{c1::Photosynthesis}} is a process.` — no real cue). Make it a Basic Q or add
+  real context.
+
+---
+
+## Cloze deep-dive
+
+Cloze syntax: `{{c1::answer}}` or with a hint `{{c1::answer::hint}}`.
+
+**Grouping with c-numbers** controls how many cards one note generates:
+- **Same number** = revealed **together on one card**. Use when the blanks are a
+  single unit you'd recall at once.
+  - `Water is {{c1::two}} parts {{c1::hydrogen}}, one part {{c1::oxygen}}.`
+    → one card hiding all three.
+- **Different numbers** = **separate cards**, each hiding only its own blank
+  (the others stay visible as context).
+  - `{{c1::Newton}}'s {{c2::second}} law: F = ma.` → two cards.
+
+**When to split into separate notes vs share one note**: if the blanks test
+genuinely different facts, prefer different c-numbers (separate cards) or separate
+notes so scheduling is independent. Share `c1` only for a tight unit.
+
+**Overlapping clozes**: to test members of a group one-at-a-time while keeping the
+rest as context, give each its own number on the *same* sentence. This is the
+right replacement for an enumeration (see below).
+
+**Hints** (`::hint`) normalize giveaways and disambiguate: use a category word, a
+first letter, or a unit — never the answer itself.
+
+---
+
+## Bad → good gallery
+
+**Enumeration → overlapping cloze (or atomic cards)**
+- ❌ Front: `List the four chambers of the heart.` Back: `LA, RA, LV, RV`
+- ✅ `The heart's upper chambers are the {{c1::atria}} and lower chambers the {{c2::ventricles}}.`
+- ✅ (atomic) `What heart chamber pumps blood to the body?` → `Left ventricle`
+
+**Paragraph dump → atomic cards**
+- ❌ Front: `Explain the French Revolution.` Back: *(three sentences)*
+- ✅ `The French Revolution began in {{c1::1789}}.`
+- ✅ `What event on 14 July 1789 sparked the French Revolution?` → `The storming of the Bastille`
+
+**Ambiguous cue → precise cue**
+- ❌ `Einstein?` → `Relativity` (many possible answers)
+- ✅ `Which physicist published the theory of general relativity (1915)?` → `Albert Einstein`
+
+**Giveaway cloze → hinted cloze**
+- ❌ `Mitochondria produce {{c1::ATP}} via aerobic respiration.` (fine) but
+  `The powerhouse organelle is the {{c1::mitochondrion}}.` reversed cue is weak
+- ✅ `The cell's main {{c1::ATP::molecule}}-producing organelle is the mitochondrion.`
+
+**Two facts → two cards**
+- ❌ `Paris is the capital of {{c1::France}}, whose currency is the {{c1::euro}}.`
+- ✅ split: `Paris is the capital of {{c1::France}}.` and
+  `The currency of France is the {{c1::euro}}.`
+
+---
+
+## Pre-build self-review checklist
+
+Run this over **every** drafted card before building the deck or adding notes:
+
+1. **Atomic?** One fact, one answer, ≤ ~10 s to recall. If not → split.
+2. **Unambiguous?** Exactly one correct answer for the cue. If not → add context.
+3. **Right type?** Cloze for facts-in-context, Basic for Q→A, Reversed only when
+   both directions are unambiguous.
+4. **Cloze sane?** 1–3 deletions, no giveaways, correct c-number grouping.
+5. **No lists/sets/dumps?** Reformulated into atomic or overlapping-cloze cards.
+6. **Stands alone?** No "see above"/source references; topic tag added if the cue
+   needs a domain.
+7. **Short answer?** If the back is long, it's multiple cards.
+8. **Worth it?** Low-value trivia cut.

--- a/docs/skills/anki/reference/json-schema.md
+++ b/docs/skills/anki/reference/json-schema.md
@@ -1,0 +1,76 @@
+# `cards.json` schema
+
+The single card format consumed by every `anki-tools` command
+(`anki-build-deck`, `anki-add-notes`). Author cards as one JSON object.
+
+```json
+{
+  "deck": "Biology::Cell",
+  "tags": ["bio", "exam1"],
+  "notes": [
+    {
+      "type": "basic",
+      "front": "What enzyme unwinds DNA at the replication fork?",
+      "back": "Helicase",
+      "extra": "It breaks hydrogen bonds between base pairs.",
+      "tags": ["replication"]
+    },
+    {
+      "type": "reversed",
+      "front": "perro",
+      "back": "dog"
+    },
+    {
+      "type": "cloze",
+      "text": "The {{c1::mitochondrion}} produces most of the cell's {{c2::ATP}}.",
+      "extra": "Via oxidative phosphorylation.",
+      "media": ["mitochondrion.png"]
+    }
+  ]
+}
+```
+
+## Top-level fields
+
+| Field   | Required | Meaning |
+|---------|----------|---------|
+| `deck`  | no (default `"Default"`) | Deck name. Use `::` for sub-decks, e.g. `"Spanish::Verbs"`. |
+| `tags`  | no | Tags applied to **every** note, merged with each note's own `tags`. |
+| `notes` | **yes** | Non-empty list of note objects. |
+
+## Note objects
+
+Every note has a `type` of `"basic"`, `"reversed"`, or `"cloze"`.
+
+**Common optional keys** (all types):
+- `extra` — supplementary text shown under the answer (e.g. a mnemonic, source).
+- `tags` — list of tags for this note (merged with top-level `tags`). Whitespace
+  in a tag is converted to `_` (Anki forbids spaces in tags).
+- `media` — list of file paths referenced by the note, resolved **relative to the
+  `cards.json` file**. Reference them by **basename** in the HTML, e.g.
+  `"front": "<img src=\"mitochondrion.png\">"` with `"media": ["mitochondrion.png"]`.
+
+**`basic`** and **`reversed`** require:
+- `front` — the prompt (non-empty).
+- `back` — the answer (non-empty).
+
+`reversed` additionally generates the back→front card. Only use it when both
+directions are unambiguous (see `card-writing.md`).
+
+**`cloze`** requires:
+- `text` — contains at least one `{{c1::answer}}` (or `{{c1::answer::hint}}`)
+  deletion. Use `c1`, `c2`, … to control card grouping (same number = one card,
+  different numbers = separate cards).
+
+## Notes & behavior
+
+- **HTML is allowed** in `front`/`back`/`text`/`extra` (`<b>`, `<br>`, `<img>`,
+  `<ul>`, …). Escape literal `<`, `>`, `&` as `&lt; &gt; &amp;`.
+- **Stable IDs / dedup**: `anki-build-deck` derives deterministic note GUIDs from
+  the prompt side, so rebuilding and re-importing **updates** existing notes
+  instead of duplicating. `anki-add-notes` uses AnkiConnect's `canAddNotes` to
+  skip duplicates (override with `--allow-duplicate`).
+- **Extra field caveat for AnkiConnect**: Anki's built-in *Basic* note type has
+  no Extra field, so `anki-add-notes` appends `extra` to the Back for
+  basic/reversed; for cloze it uses the native "Back Extra" field. The
+  `.apkg` path (`anki-build-deck`) uses dedicated Extra fields on all types.

--- a/modules/productivity/anki-tools.nix
+++ b/modules/productivity/anki-tools.nix
@@ -1,0 +1,24 @@
+{
+  rootPath,
+  withSystem,
+  ...
+}:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      packages.anki-tools = pkgs.python3Packages.callPackage "${rootPath}/pkgs/anki-tools" { };
+    };
+
+  # Ship the CLI alongside the Anki GUI (and its anki-connect add-on).
+  flake.modules.homeManager.gui =
+    { pkgs, ... }:
+    let
+      anki-tools = withSystem pkgs.stdenv.hostPlatform.system (
+        psArgs: psArgs.config.packages.anki-tools
+      );
+    in
+    {
+      home.packages = [ anki-tools ];
+    };
+}

--- a/pkgs/anki-tools/anki_tools/__init__.py
+++ b/pkgs/anki-tools/anki_tools/__init__.py
@@ -1,0 +1,11 @@
+"""anki-tools: build .apkg decks and push cards to a running Anki.
+
+A single `cards.json` schema drives every entry point:
+
+  anki-build-deck   cards.json -> .apkg            (genanki)
+  anki-parse-deck   .apkg      -> cards.json        (round-trip editing)
+  anki-add-notes    cards.json -> running Anki      (AnkiConnect)
+  anki-connect      <action>   -> running Anki      (ad-hoc AnkiConnect calls)
+"""
+
+__version__ = "0.1.0"

--- a/pkgs/anki-tools/anki_tools/_ankiconnect.py
+++ b/pkgs/anki-tools/anki_tools/_ankiconnect.py
@@ -1,0 +1,52 @@
+"""Minimal AnkiConnect client (stdlib only).
+
+AnkiConnect exposes Anki over HTTP at http://127.0.0.1:8765. Every request is a
+POST with body {"action", "version": 6, "params"} and the response is
+{"result", "error"}.
+"""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+
+DEFAULT_ENDPOINT = "http://127.0.0.1:8765"
+API_VERSION = 6
+
+
+class AnkiConnectError(RuntimeError):
+    """An AnkiConnect call returned a non-null ``error`` or was unreachable."""
+
+
+def invoke(
+    action: str,
+    params: dict | None = None,
+    endpoint: str = DEFAULT_ENDPOINT,
+    timeout: float = 10.0,
+):
+    """Call an AnkiConnect ``action`` and return its ``result``.
+
+    Raises AnkiConnectError if Anki/AnkiConnect is unreachable or returns an
+    error.
+    """
+    payload = json.dumps(
+        {"action": action, "version": API_VERSION, "params": params or {}}
+    ).encode("utf-8")
+    request = urllib.request.Request(
+        endpoint, data=payload, headers={"Content-Type": "application/json"}
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            data = json.load(response)
+    except urllib.error.URLError as e:
+        raise AnkiConnectError(
+            f"cannot reach AnkiConnect at {endpoint}: {e}. "
+            "Is Anki running with the AnkiConnect add-on installed?"
+        ) from e
+
+    if not isinstance(data, dict) or "error" not in data or "result" not in data:
+        raise AnkiConnectError(f"unexpected AnkiConnect response: {data!r}")
+    if data["error"] is not None:
+        raise AnkiConnectError(data["error"])
+    return data["result"]

--- a/pkgs/anki-tools/anki_tools/_common.py
+++ b/pkgs/anki-tools/anki_tools/_common.py
@@ -1,0 +1,158 @@
+"""Shared helpers: cards.json loading/validation, stable IDs, cloze parsing.
+
+This module is deliberately dependency-free (stdlib only) so that the
+AnkiConnect entry points work even where genanki is unavailable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from pathlib import Path
+
+# genanki requires model/deck IDs in the half-open range [1<<30, 1<<31).
+_ID_LO = 1 << 30
+_ID_HI = 1 << 31
+
+# Anki cloze markers look like {{c1::answer}} or {{c1::answer::hint}}.
+_CLOZE_NUM_RE = re.compile(r"\{\{c(\d+)::")
+
+NOTE_TYPES = ("basic", "reversed", "cloze")
+
+
+class CardError(ValueError):
+    """Raised for malformed cards.json input, with a human-readable message."""
+
+
+def stable_id(seed: str) -> int:
+    """Deterministic genanki id in [1<<30, 1<<31) derived from a seed string.
+
+    Using a fixed seed keeps deck/model IDs stable across runs so re-importing a
+    rebuilt deck updates the existing notes rather than creating duplicates.
+    """
+    h = int(hashlib.md5(seed.encode()).hexdigest(), 16)
+    return _ID_LO + (h % (_ID_HI - _ID_LO))
+
+
+def cloze_numbers(text: str) -> list[int]:
+    """Return the sorted unique cloze indices (1 for c1, 2 for c2, ...) in text."""
+    return sorted({int(m.group(1)) for m in _CLOZE_NUM_RE.finditer(text)})
+
+
+def sanitize_tag(tag: str) -> str:
+    """Anki tags cannot contain whitespace; collapse runs to underscores."""
+    return re.sub(r"\s+", "_", str(tag).strip())
+
+
+def _require(cond: bool, msg: str) -> None:
+    if not cond:
+        raise CardError(msg)
+
+
+def load_cards(path: str | Path) -> dict:
+    """Load and validate a cards.json file into a normalized structure:
+
+        {
+          "deck": str,
+          "tags": [str],
+          "media_root": Path,   # directory media paths are resolved against
+          "notes": [ <note>, ... ],
+        }
+
+    where each <note> is one of:
+
+        {"type": "basic"|"reversed", "front", "back", "extra", "tags", "media"}
+        {"type": "cloze",            "text",          "extra", "tags", "media"}
+    """
+    path = Path(path)
+    _require(path.is_file(), f"cards file not found: {path}")
+    try:
+        raw = json.loads(path.read_text())
+    except json.JSONDecodeError as e:
+        raise CardError(f"{path}: invalid JSON: {e}") from e
+
+    _require(isinstance(raw, dict), "top level of cards.json must be a JSON object")
+
+    deck = raw.get("deck", "Default")
+    _require(
+        isinstance(deck, str) and deck.strip(),
+        "'deck' must be a non-empty string",
+    )
+
+    deck_tags = raw.get("tags", [])
+    _require(isinstance(deck_tags, list), "'tags' must be a list of strings")
+
+    notes_raw = raw.get("notes")
+    _require(
+        isinstance(notes_raw, list) and notes_raw,
+        "'notes' must be a non-empty list",
+    )
+
+    notes = [_normalize_note(i, n, deck_tags) for i, n in enumerate(notes_raw)]
+
+    return {
+        "deck": deck.strip(),
+        "tags": [sanitize_tag(t) for t in deck_tags],
+        "media_root": path.resolve().parent,
+        "notes": notes,
+    }
+
+
+def _normalize_note(idx: int, note: dict, deck_tags: list) -> dict:
+    where = f"notes[{idx}]"
+    _require(isinstance(note, dict), f"{where} must be an object")
+
+    ntype = note.get("type")
+    _require(
+        ntype in NOTE_TYPES,
+        f"{where}: 'type' must be one of {NOTE_TYPES}, got {ntype!r}",
+    )
+
+    # Merge per-note tags with deck-level tags, de-duplicating, preserving order.
+    raw_tags = [*note.get("tags", []), *deck_tags]
+    tags = list(dict.fromkeys(sanitize_tag(t) for t in raw_tags if str(t).strip()))
+
+    media = note.get("media", [])
+    _require(isinstance(media, list), f"{where}: 'media' must be a list of paths")
+    media = [str(m) for m in media]
+
+    extra = str(note.get("extra", "") or "")
+
+    if ntype in ("basic", "reversed"):
+        front = note.get("front")
+        back = note.get("back")
+        _require(
+            isinstance(front, str) and front.strip(),
+            f"{where}: '{ntype}' needs a non-empty 'front'",
+        )
+        _require(
+            isinstance(back, str) and back.strip(),
+            f"{where}: '{ntype}' needs a non-empty 'back'",
+        )
+        return {
+            "type": ntype,
+            "front": front,
+            "back": back,
+            "extra": extra,
+            "tags": tags,
+            "media": media,
+        }
+
+    # cloze
+    text = note.get("text")
+    _require(
+        isinstance(text, str) and text.strip(),
+        f"{where}: 'cloze' needs a non-empty 'text'",
+    )
+    _require(
+        cloze_numbers(text),
+        f"{where}: 'cloze' text has no {{{{cN::...}}}} deletions: {text!r}",
+    )
+    return {
+        "type": "cloze",
+        "text": text,
+        "extra": extra,
+        "tags": tags,
+        "media": media,
+    }

--- a/pkgs/anki-tools/anki_tools/add_notes.py
+++ b/pkgs/anki-tools/anki_tools/add_notes.py
@@ -1,0 +1,114 @@
+"""anki-add-notes: push a cards.json file into a running Anki via AnkiConnect.
+
+Uses Anki's built-in note types (Basic, Basic (and reversed card), Cloze) so the
+cards look native. Because Basic has no Extra field, a note's ``extra`` is
+appended to the Back; the Cloze note type's native "Back Extra" field is used for
+cloze extras.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from ._ankiconnect import DEFAULT_ENDPOINT, AnkiConnectError, invoke
+from ._common import CardError, load_cards
+
+_MODEL_BASIC = "Basic"
+_MODEL_REVERSED = "Basic (and reversed card)"
+_MODEL_CLOZE = "Cloze"
+
+
+def _ac_note(card: dict, deck_name: str, allow_duplicate: bool) -> dict:
+    if card["type"] == "cloze":
+        fields = {"Text": card["text"]}
+        if card["extra"]:
+            fields["Back Extra"] = card["extra"]
+        model = _MODEL_CLOZE
+    else:
+        back = card["back"]
+        if card["extra"]:
+            back += f'<br><div class="extra">{card["extra"]}</div>'
+        fields = {"Front": card["front"], "Back": back}
+        model = _MODEL_REVERSED if card["type"] == "reversed" else _MODEL_BASIC
+
+    return {
+        "deckName": deck_name,
+        "modelName": model,
+        "fields": fields,
+        "tags": card["tags"],
+        "options": {"allowDuplicate": allow_duplicate},
+    }
+
+
+def _store_media(data: dict, endpoint: str) -> None:
+    for card in data["notes"]:
+        for rel in card["media"]:
+            path = (data["media_root"] / rel).resolve()
+            if not path.is_file():
+                print(f"warning: media file not found, skipping: {path}", file=sys.stderr)
+                continue
+            invoke("storeMediaFile", {"filename": path.name, "path": str(path)}, endpoint)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="anki-add-notes",
+        description="Push a cards.json file into a running Anki via AnkiConnect.",
+    )
+    parser.add_argument("cards", help="path to a cards.json file")
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT, help="AnkiConnect URL")
+    parser.add_argument(
+        "--allow-duplicate",
+        action="store_true",
+        help="add notes even if Anki considers them duplicates",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print the addNotes payload without contacting Anki",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        data = load_cards(args.cards)
+    except CardError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    notes = [_ac_note(c, data["deck"], args.allow_duplicate) for c in data["notes"]]
+
+    if args.dry_run:
+        payload = {"action": "addNotes", "version": 6, "params": {"notes": notes}}
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0
+
+    try:
+        invoke("version", endpoint=args.endpoint)
+        invoke("createDeck", {"deck": data["deck"]}, args.endpoint)
+        _store_media(data, args.endpoint)
+
+        addable_flags = invoke("canAddNotes", {"notes": notes}, args.endpoint)
+        addable = [n for n, ok in zip(notes, addable_flags) if ok]
+        skipped = len(notes) - len(addable)
+
+        results = invoke("addNotes", {"notes": addable}, args.endpoint) if addable else []
+    except AnkiConnectError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    added = sum(1 for r in results if r)
+    failed = len(addable) - added
+    msg = f"Added {added} note(s) to '{data['deck']}'"
+    if skipped:
+        msg += f", skipped {skipped} duplicate/invalid"
+    if failed:
+        msg += f", {failed} failed"
+    print(msg + ".")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/anki-tools/anki_tools/build_deck.py
+++ b/pkgs/anki-tools/anki_tools/build_deck.py
@@ -1,0 +1,159 @@
+"""anki-build-deck: build a portable .apkg deck from a cards.json file."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import genanki
+
+from ._common import CardError, load_cards, stable_id
+
+# Shared styling for all generated note types.
+_CSS = """
+.card {
+  font-family: -apple-system, system-ui, "Segoe UI", sans-serif;
+  font-size: 20px;
+  line-height: 1.5;
+  text-align: center;
+  color: #1a1a1a;
+  background-color: #ffffff;
+}
+.extra {
+  font-size: 15px;
+  color: #555;
+  margin-top: 0.7em;
+}
+.cloze {
+  font-weight: bold;
+  color: #1565c0;
+}
+"""
+
+_QA_AFMT = (
+    '{{FrontSide}}<hr id="answer">{{%s}}'
+    '{{#Extra}}<div class="extra">{{Extra}}</div>{{/Extra}}'
+)
+
+# Fixed model IDs (via stable_id) so re-importing a rebuilt deck updates the same
+# note types instead of spawning duplicates.
+BASIC_MODEL = genanki.Model(
+    model_id=stable_id("anki-tools/model/basic/v1"),
+    name="anki-tools Basic",
+    fields=[{"name": "Front"}, {"name": "Back"}, {"name": "Extra"}],
+    templates=[
+        {"name": "Card 1", "qfmt": "{{Front}}", "afmt": _QA_AFMT % "Back"},
+    ],
+    css=_CSS,
+)
+
+REVERSED_MODEL = genanki.Model(
+    model_id=stable_id("anki-tools/model/reversed/v1"),
+    name="anki-tools Basic (and reversed card)",
+    fields=[{"name": "Front"}, {"name": "Back"}, {"name": "Extra"}],
+    templates=[
+        {"name": "Card 1", "qfmt": "{{Front}}", "afmt": _QA_AFMT % "Back"},
+        {"name": "Card 2", "qfmt": "{{Back}}", "afmt": _QA_AFMT % "Front"},
+    ],
+    css=_CSS,
+)
+
+CLOZE_MODEL = genanki.Model(
+    model_id=stable_id("anki-tools/model/cloze/v1"),
+    name="anki-tools Cloze",
+    model_type=genanki.Model.CLOZE,
+    fields=[{"name": "Text"}, {"name": "Extra"}],
+    templates=[
+        {
+            "name": "Cloze",
+            "qfmt": "{{cloze:Text}}",
+            "afmt": (
+                "{{cloze:Text}}"
+                '{{#Extra}}<div class="extra">{{Extra}}</div>{{/Extra}}'
+            ),
+        }
+    ],
+    css=_CSS,
+)
+
+
+def _note_for(card: dict, deck_name: str) -> genanki.Note:
+    """Build a genanki.Note with a deterministic GUID for stable re-imports.
+
+    The GUID is keyed on the *prompt* side (front, or full cloze text) so that
+    editing the answer of a Basic card updates the same note on re-import.
+    """
+    if card["type"] == "cloze":
+        guid = genanki.guid_for(f"{deck_name}|cloze|{card['text']}")
+        return genanki.Note(
+            model=CLOZE_MODEL,
+            fields=[card["text"], card["extra"]],
+            tags=card["tags"],
+            guid=guid,
+        )
+
+    model = BASIC_MODEL if card["type"] == "basic" else REVERSED_MODEL
+    guid = genanki.guid_for(f"{deck_name}|{card['type']}|{card['front']}")
+    return genanki.Note(
+        model=model,
+        fields=[card["front"], card["back"], card["extra"]],
+        tags=card["tags"],
+        guid=guid,
+    )
+
+
+def _default_output(deck_name: str) -> str:
+    safe = deck_name.replace("::", "__").replace(" ", "_")
+    return f"{safe}.apkg"
+
+
+def build(data: dict, output: Path) -> int:
+    deck = genanki.Deck(
+        deck_id=stable_id(f"anki-tools/deck/{data['deck']}"),
+        name=data["deck"],
+    )
+
+    media_files: list[str] = []
+    for card in data["notes"]:
+        deck.add_note(_note_for(card, data["deck"]))
+        for rel in card["media"]:
+            path = (data["media_root"] / rel).resolve()
+            if not path.is_file():
+                print(f"warning: media file not found, skipping: {path}", file=sys.stderr)
+                continue
+            media_files.append(str(path))
+
+    package = genanki.Package(deck)
+    package.media_files = sorted(set(media_files))
+    package.write_to_file(str(output))
+    return len(data["notes"])
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="anki-build-deck",
+        description="Build a portable .apkg deck from a cards.json file.",
+    )
+    parser.add_argument("cards", help="path to a cards.json file")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="output .apkg path (default: <deck-name>.apkg)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        data = load_cards(args.cards)
+    except CardError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    output = Path(args.output) if args.output else Path(_default_output(data["deck"]))
+    n = build(data, output)
+    print(f"Wrote {n} note(s) to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/anki-tools/anki_tools/connect.py
+++ b/pkgs/anki-tools/anki_tools/connect.py
@@ -1,0 +1,53 @@
+"""anki-connect: run an arbitrary AnkiConnect action from the command line.
+
+Examples:
+  anki-connect version
+  anki-connect deckNames
+  anki-connect findNotes '{"query": "deck:Spanish"}'
+  anki-connect guiBrowse '{"query": "tag:exam1"}'
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from ._ankiconnect import DEFAULT_ENDPOINT, AnkiConnectError, invoke
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="anki-connect",
+        description="Run an AnkiConnect action and print its JSON result.",
+    )
+    parser.add_argument("action", help="AnkiConnect action name, e.g. 'deckNames'")
+    parser.add_argument(
+        "params",
+        nargs="?",
+        help="action parameters as a JSON object string",
+    )
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT, help="AnkiConnect URL")
+    args = parser.parse_args(argv)
+
+    try:
+        params = json.loads(args.params) if args.params else {}
+    except json.JSONDecodeError as e:
+        print(f"error: params is not valid JSON: {e}", file=sys.stderr)
+        return 1
+    if not isinstance(params, dict):
+        print("error: params must be a JSON object", file=sys.stderr)
+        return 1
+
+    try:
+        result = invoke(args.action, params, args.endpoint)
+    except AnkiConnectError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/anki-tools/anki_tools/parse_deck.py
+++ b/pkgs/anki-tools/anki_tools/parse_deck.py
@@ -1,0 +1,163 @@
+"""anki-parse-deck: extract a .apkg back into cards.json for round-trip editing.
+
+Reads the SQLite collection inside the .apkg (stdlib only) and maps notes back
+to the shared schema. Handles the legacy ``collection.anki2`` schema written by
+genanki/older Anki and the ``collection.anki21`` schema. The newest zstd-packed
+``collection.anki21b`` export format is not supported; re-export with "Support
+older Anki versions" enabled if you hit that.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+import tempfile
+import zipfile
+from pathlib import Path
+
+# Anki separates the fields of a note with the unit-separator control char.
+_FIELD_SEP = "\x1f"
+
+
+def _extract_db(apkg: Path, dest: Path) -> Path:
+    with zipfile.ZipFile(apkg) as zf:
+        names = set(zf.namelist())
+        for candidate in ("collection.anki21", "collection.anki2"):
+            if candidate in names:
+                zf.extract(candidate, dest)
+                return dest / candidate
+        if "collection.anki21b" in names:
+            raise SystemExit(
+                "error: this .apkg uses the new packed format (collection.anki21b),"
+                " which is not supported. Re-export with 'Support older Anki"
+                " versions' enabled."
+            )
+    raise SystemExit("error: no collection database found inside the .apkg")
+
+
+def _models(cur: sqlite3.Cursor) -> dict[int, dict]:
+    """Return {mid: {"name": str, "is_cloze": bool, "n_templates": int}}."""
+    # Legacy schema: a single JSON blob in col.models.
+    try:
+        row = cur.execute("SELECT models FROM col").fetchone()
+    except sqlite3.OperationalError:
+        row = None
+    if row and row[0]:
+        out = {}
+        for mid, m in json.loads(row[0]).items():
+            out[int(mid)] = {
+                "name": m.get("name", ""),
+                "is_cloze": m.get("type", 0) == 1,
+                "n_templates": len(m.get("tmpls", []) or []),
+            }
+        if out:
+            return out
+
+    # Modern schema: notetypes + templates tables.
+    out = {}
+    for mid, name, mtype in cur.execute("SELECT id, name, type FROM notetypes"):
+        n_tmpl = cur.execute(
+            "SELECT COUNT(*) FROM templates WHERE ntid = ?", (mid,)
+        ).fetchone()[0]
+        out[int(mid)] = {
+            "name": name,
+            "is_cloze": mtype == 1,
+            "n_templates": n_tmpl,
+        }
+    return out
+
+
+def _deck_names(cur: sqlite3.Cursor) -> dict[int, str]:
+    try:
+        row = cur.execute("SELECT decks FROM col").fetchone()
+        if row and row[0]:
+            return {int(did): d.get("name", "") for did, d in json.loads(row[0]).items()}
+    except sqlite3.OperationalError:
+        pass
+    try:
+        return {int(did): name for did, name in cur.execute("SELECT id, name FROM decks")}
+    except sqlite3.OperationalError:
+        return {}
+
+
+def parse(apkg: Path) -> dict:
+    with tempfile.TemporaryDirectory(prefix="anki_parse_") as tmp:
+        db = _extract_db(apkg, Path(tmp))
+        con = sqlite3.connect(db)
+        try:
+            cur = con.cursor()
+            models = _models(cur)
+            deck_names = _deck_names(cur)
+
+            # Pick the most common non-"Default" deck as the deck name.
+            deck_counts: dict[str, int] = {}
+            for (did,) in cur.execute("SELECT DISTINCT did FROM cards"):
+                name = deck_names.get(int(did), "")
+                if name and name != "Default":
+                    deck_counts[name] = deck_counts.get(name, 0) + 1
+            deck = max(deck_counts, key=deck_counts.get) if deck_counts else "Default"
+
+            notes = []
+            for mid, flds, tags in cur.execute("SELECT mid, flds, tags FROM notes"):
+                model = models.get(int(mid), {})
+                fields = flds.split(_FIELD_SEP)
+                tag_list = [t for t in tags.split(" ") if t]
+                notes.append(_note_to_schema(model, fields, tag_list))
+        finally:
+            con.close()
+
+    return {"deck": deck, "tags": [], "notes": notes}
+
+
+def _note_to_schema(model: dict, fields: list[str], tags: list[str]) -> dict:
+    extra = fields[2] if len(fields) > 2 else ""
+    if model.get("is_cloze"):
+        note = {"type": "cloze", "text": fields[0] if fields else ""}
+        cloze_extra = fields[1] if len(fields) > 1 else ""
+        if cloze_extra:
+            note["extra"] = cloze_extra
+    else:
+        ntype = "reversed" if model.get("n_templates", 1) >= 2 else "basic"
+        note = {
+            "type": ntype,
+            "front": fields[0] if fields else "",
+            "back": fields[1] if len(fields) > 1 else "",
+        }
+        if extra:
+            note["extra"] = extra
+    if tags:
+        note["tags"] = tags
+    return note
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="anki-parse-deck",
+        description="Extract a .apkg into cards.json (printed to stdout).",
+    )
+    parser.add_argument("apkg", help="path to a .apkg file")
+    parser.add_argument(
+        "-o",
+        "--output",
+        help="write JSON here instead of stdout",
+    )
+    args = parser.parse_args(argv)
+
+    apkg = Path(args.apkg)
+    if not apkg.is_file():
+        print(f"error: file not found: {apkg}", file=sys.stderr)
+        return 1
+
+    data = parse(apkg)
+    text = json.dumps(data, indent=2, ensure_ascii=False)
+    if args.output:
+        Path(args.output).write_text(text + "\n")
+    else:
+        print(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pkgs/anki-tools/default.nix
+++ b/pkgs/anki-tools/default.nix
@@ -1,0 +1,27 @@
+{
+  lib,
+  buildPythonApplication,
+  setuptools,
+  genanki,
+}:
+buildPythonApplication {
+  pname = "anki-tools";
+  version = "0.1.0";
+  src = ./.;
+  pyproject = true;
+
+  build-system = [ setuptools ];
+
+  # Only build_deck needs genanki; parse/add/connect are pure stdlib. They all
+  # share one environment, so genanki is propagated for the whole package.
+  propagatedBuildInputs = [ genanki ];
+
+  doCheck = false;
+
+  meta = {
+    description = "Build .apkg decks and push cards to a running Anki from a shared cards.json schema";
+    license = lib.licenses.mit;
+    maintainers = with lib.maintainers; [ Multipixelone ];
+    mainProgram = "anki-build-deck";
+  };
+}

--- a/pkgs/anki-tools/pyproject.toml
+++ b/pkgs/anki-tools/pyproject.toml
@@ -1,0 +1,19 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "anki-tools"
+version = "0.1.0"
+description = "Build .apkg decks and push cards to a running Anki from a shared cards.json schema"
+requires-python = ">=3.11"
+dependencies = ["genanki"]
+
+[project.scripts]
+anki-build-deck = "anki_tools.build_deck:main"
+anki-parse-deck = "anki_tools.parse_deck:main"
+anki-add-notes = "anki_tools.add_notes:main"
+anki-connect = "anki_tools.connect:main"
+
+[tool.setuptools.packages.find]
+where = ["."]


### PR DESCRIPTION
Two sibling Claude skills for making high-quality flashcards, sharing one
card-writing methodology and one cards.json schema:

- docs/skills/anki        : draft cards -> portable .apkg (genanki), plus
                            round-trip .apkg -> cards.json editing
- docs/skills/anki-connect: push the same cards live into a running Anki via
                            the AnkiConnect add-on (HTTP localhost:8765)

The methodology (minimum information principle, the 20 rules, an opinionated
Basic vs Cloze vs Basic+Reversed decision tree, cloze deep-dive, bad->good
gallery, and a pre-build review checklist) lives once in
docs/skills/anki/reference/card-writing.md.

All executable logic is a proper Nix package (pkgs/anki-tools), wired into the
flake like pkgs/asl-anki via modules/productivity/anki-tools.nix and shipped on
home.packages alongside the Anki GUI. Entry points: anki-build-deck,
anki-parse-deck, anki-add-notes, anki-connect. Only build_deck needs genanki;
the AnkiConnect paths are pure stdlib.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SL11yrz5FCNh4f9d4748ui