### PR TITLE
feat: switch fi (darwin) to Determinate Nix, keep caches declarative

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -99,6 +99,7 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     commutecompass.url = "github:Multipixelone/commutecompass";
+    determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/3";
     euphony = {
       url = "github:Multipixelone/euphony/nix-build";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/modules/fi/determinate.nix
+++ b/modules/fi/determinate.nix
@@ -1,0 +1,36 @@
+{ inputs, config, ... }:
+{
+  # Determinate Nix manages /etc/nix on this host instead of nix-darwin.
+  # `determinate.darwinModules.default` forces `nix.enable = false` (so
+  # nix-darwin no longer writes /etc/nix/nix.conf) and exposes Determinate's
+  # own declarative surface under `determinateNix.*`, which writes
+  # /etc/nix/nix.custom.conf and /etc/determinate/config.json. This keeps the
+  # store intact (no reinstall) while everything below stays in the flake.
+  configurations.darwin.fi.module = {
+    imports = [ inputs.determinate.darwinModules.default ];
+
+    determinateNix = {
+      # `enable` defaults to true once the module is imported; spelled out here
+      # so the intent is visible at the host level.
+      enable = true;
+
+      # Custom Nix settings -> /etc/nix/nix.custom.conf. Determinate already
+      # turns on nix-command + flakes and trusts cache.nixos.org / the FlakeHub
+      # cache, so these are all `extra-*` (additive) to avoid clobbering its
+      # defaults. Substituters reuse the repo-wide `caches` aggregate
+      # (modules/nixpkgs/substituters.nix) so the Mac stays in sync with the
+      # NixOS hosts and the flake's own nixConfig.
+      customSettings = {
+        extra-experimental-features = [ "pipe-operators" ];
+        trusted-users = [
+          "@admin"
+          config.flake.meta.owner.username
+        ];
+        extra-substituters = map (c: c.url) config.caches;
+        extra-trusted-public-keys = map (c: c.key) config.caches;
+      };
+    };
+  };
+
+  flake-file.inputs.determinate.url = "https://flakehub.com/f/DeterminateSystems/determinate/3";
+}

--- a/modules/fi/linux-builder.nix
+++ b/modules/fi/linux-builder.nix
@@ -2,9 +2,15 @@
   configurations.darwin.fi.module = {
     # NixOS-as-QEMU micro-VM so the Mac natively builds the repo's Linux
     # packages/wrappers (aarch64-linux via HVF fast; x86_64-linux via TCG slow)
-    # instead of relying on ARM CI runners. Routes via ssh-ng build-machine
-    # at linux-builder@localhost:31022.
-    nix.linux-builder = {
+    # instead of relying on ARM CI runners. Routes via an ssh-ng build-machine
+    # at builder@localhost:31022.
+    #
+    # This is Determinate's port of nix-darwin's `nix.linux-builder` (the same
+    # Nixpkgs darwin.linux-builder VM); nix-darwin's own block can't be used
+    # because it asserts `nix.enable`, which Determinate forces off. Determinate
+    # also ships a native (Virtualization.framework) Linux builder, but this VM
+    # keeps the existing tuning verbatim.
+    determinateNix.nixosVmBasedLinuxBuilder = {
       enable = true;
       ephemeral = true;
       systems = [

--- a/modules/fi/system.nix
+++ b/modules/fi/system.nix
@@ -7,18 +7,10 @@
     system.primaryUser = config.flake.meta.owner.username;
     system.configurationRevision = inputs.self.rev or inputs.self.dirtyRev or null;
 
-    nix.enable = true;
-    nix.settings = {
-      experimental-features = [
-        "nix-command"
-        "flakes"
-        "pipe-operators"
-      ];
-      trusted-users = [
-        "@admin"
-        config.flake.meta.owner.username
-      ];
-    };
+    # Nix itself (experimental-features, trusted-users, substituters) is managed
+    # by Determinate Nix via `determinateNix.*` in ./determinate.nix — the
+    # determinate module forces `nix.enable = false`, so nix-darwin's `nix.*`
+    # settings would be inert here.
 
     # /etc/zsh* managed by nix-darwin (PATH in non-interactive shells); HM's
     # ~/.zshrc is sourced from the system /etc/zshrc.


### PR DESCRIPTION
## What

Switch the `fi` macOS host from nix-darwin-managed Nix to **Determinate Nix**, while keeping every cache/substituter and Nix setting declarative in the flake. The store is **not** reinstalled — Determinate takes over `/etc/nix`, nix-darwin keeps doing everything else.

## How it works

Importing `inputs.determinate.darwinModules.default` does two things itself:
1. forces `nix.enable = lib.mkForce false` (nix-darwin no longer writes `/etc/nix/nix.conf`), and
2. exposes `determinateNix.*`, which writes `/etc/nix/nix.custom.conf` and `/etc/determinate/config.json`.

So this is the *third* option — not "let nix-darwin manage the install" and not "set `nix.enable = false` and hand-edit `nix.custom.conf`". Config stays in the flake under `determinateNix.*`.

## Changes

- **`modules/fi/determinate.nix`** (new) — import the Determinate darwin module and configure `determinateNix.customSettings`:
  - `extra-substituters` / `extra-trusted-public-keys` reuse the repo-wide `caches` aggregate (`modules/nixpkgs/substituters.nix`), the same list that feeds the flake `nixConfig` and the NixOS hosts — so the Mac stays in sync.
  - `extra-experimental-features = [ "pipe-operators" ]` and `trusted-users`.
  - All `extra-*` (additive) so Determinate's own defaults (nix-command/flakes, cache.nixos.org, the FlakeHub cache) are preserved rather than clobbered.
- **`modules/fi/system.nix`** — drop `nix.enable` / `nix.settings` (inert once Determinate owns `nix.conf`); those settings now live in `customSettings`.
- **`modules/fi/linux-builder.nix`** — port `nix.linux-builder` → `determinateNix.nixosVmBasedLinuxBuilder`. Same Nixpkgs `darwin.linux-builder` VM, same `ephemeral`, both `aarch64-linux`/`x86_64-linux`, same tuning (6 cores / 40 GB disk / 8 GB mem), same `builder@localhost:31022`. nix-darwin's own `nix.linux-builder` can't be used here because it asserts `nix.enable`, which Determinate forces off. (Determinate also ships a native Virtualization.framework builder; this keeps the existing VM verbatim.)
- **`flake.nix` / flake-file** — add the `determinate` input (`flakehub.com/f/DeterminateSystems/determinate/3`).

## Follow-ups before activating on the Mac

This environment has no `nix`, so two generated artifacts couldn't be produced here:

1. `flake.nix` was hand-edited to mirror what `write-flake` produces — run `nix run .#write-flake` to confirm there's no drift.
2. `flake.lock` does **not** yet contain the `determinate` input — it auto-locks on the first eval (`darwin-rebuild` / `nix flake check`), or run `nix flake lock` to lock it explicitly.

Activate with `just darwin-switch fi` (or `just darwin-bootstrap fi` on a fresh machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QiWwUjG4R8X4cN5qwng4Zn)_